### PR TITLE
Add Terraform EC2 configuration

### DIFF
--- a/infrastructure/terraform/ec2.tf
+++ b/infrastructure/terraform/ec2.tf
@@ -1,0 +1,76 @@
+variable "aws_region" {}
+variable "aws_access_key" {}
+variable "aws_secret_key" {}
+variable "key_name" {}
+
+provider "aws" {
+  region     = var.aws_region
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"]
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+}
+
+resource "aws_security_group" "trustvault_sg" {
+  name        = "trustvault-sg"
+  description = "Allow SSH and HTTP"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "trustvault" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = "t3.micro"
+  key_name      = var.key_name
+
+  vpc_security_group_ids = [aws_security_group.trustvault_sg.id]
+
+  user_data = <<-EOF2
+              #!/bin/bash
+              apt-get update
+              apt-get install -y docker.io docker-compose
+              systemctl enable docker
+              EOF2
+
+  tags = {
+    project = "trustvault"
+  }
+}
+
+output "instance_id" {
+  value = aws_instance.trustvault.id
+}
+
+output "public_ip" {
+  value = aws_instance.trustvault.public_ip
+}
+
+output "ssh_command" {
+  value = "ssh -i ~/.ssh/${var.key_name}.pem ubuntu@${aws_instance.trustvault.public_ip}"
+}


### PR DESCRIPTION
## Summary
- create Terraform config for a t3.micro instance running Ubuntu 22.04
- install Docker and Docker Compose via `user_data`
- expose SSH and HTTP ports only
- tag instance with `project = trustvault`
- output the instance ID, public IP, and SSH command

