### PR TITLE
Implement Kafka orchestrator

### DIFF
--- a/ai_service/kafka_orchestrator.py
+++ b/ai_service/kafka_orchestrator.py
@@ -1,0 +1,215 @@
+import asyncio
+import json
+import logging
+import os
+import signal
+from typing import Dict, Any, Optional, Tuple
+
+from aiokafka import AIOKafkaConsumer, AIOKafkaProducer, TopicPartition, OffsetAndMetadata
+from aiokafka.errors import KafkaError
+from prometheus_client import Gauge, Counter, CONTENT_TYPE_LATEST, CollectorRegistry, generate_latest
+from aiohttp import web
+import structlog
+
+from .settings import Settings
+from .pipeline import process_event
+
+
+# Prometheus metrics
+registry = CollectorRegistry()
+QUEUE_GAUGE = Gauge("in_flight_queue", "In-flight queue size", registry=registry)
+LAG_GAUGE = Gauge("consumer_lag", "Kafka consumer lag", registry=registry)
+PROCESSED_COUNTER = Counter("events_processed_total", "Processed events", registry=registry)
+
+
+def configure_logging(env: str) -> structlog.BoundLogger:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    structlog.configure(processors=[structlog.processors.JSONRenderer()])
+    return structlog.get_logger().bind(service="ai-orchestrator", environment=env)
+
+
+async def metrics_app() -> web.AppRunner:
+    async def handle(_request: web.Request) -> web.Response:
+        data = generate_latest(registry)
+        return web.Response(body=data, content_type=CONTENT_TYPE_LATEST)
+
+    app = web.Application()
+    app.router.add_get("/metrics", handle)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "0.0.0.0", 9000)
+    await site.start()
+    return runner
+
+
+async def process_kafka_message(
+    msg: Any,
+    producer: AIOKafkaProducer,
+    group_id: str,
+    logger: structlog.BoundLogger,
+) -> None:
+    attempts = 0
+    while True:
+        producer.begin_transaction()
+        try:
+            try:
+                event_dict = json.loads(msg.value.decode("utf-8"))
+            except json.JSONDecodeError:
+                await producer.send_and_wait(
+                    "rau_events_dlq",
+                    msg.value,
+                    headers=[("reason", b"deserialization_error")],
+                )
+                offsets = {
+                    TopicPartition(msg.topic, msg.partition): OffsetAndMetadata(
+                        msg.offset + 1, None
+                    )
+                }
+                await producer.send_offsets_to_transaction(offsets, group_id)
+                await producer.commit_transaction()
+                return
+
+            topic, value, headers = await process_event(event_dict)
+            headers = [
+                (str(k), str(v).encode("utf-8")) for k, v in (headers or {}).items()
+            ]
+            await producer.send_and_wait(
+                topic, json.dumps(value).encode("utf-8"), headers=headers
+            )
+            offsets = {
+                TopicPartition(msg.topic, msg.partition): OffsetAndMetadata(
+                    msg.offset + 1, None
+                )
+            }
+            await producer.send_offsets_to_transaction(offsets, group_id)
+            await producer.commit_transaction()
+            PROCESSED_COUNTER.inc()
+            return
+        except KafkaError as e:
+            await producer.abort_transaction()
+            attempts += 1
+            if attempts > 3:
+                logger.error("kafka_error", error=str(e), attempt=attempts)
+                raise
+            wait = 2 ** attempts
+            logger.warning("kafka_retry", attempt=attempts, wait=wait)
+            await asyncio.sleep(wait)
+
+
+async def consume_loop(
+    consumer: AIOKafkaConsumer,
+    queue: asyncio.Queue,
+    stop_event: asyncio.Event,
+    logger: structlog.BoundLogger,
+) -> None:
+    while not stop_event.is_set():
+        msg = await consumer.getone()
+        await queue.put(msg)
+        QUEUE_GAUGE.set(queue.qsize())
+        tp = TopicPartition(msg.topic, msg.partition)
+        try:
+            lag = consumer.highwater(tp) - msg.offset - 1
+            LAG_GAUGE.set(lag)
+        except Exception:
+            pass
+        if queue.qsize() > 10000:
+            consumer.pause(*consumer.assignment())
+        elif queue.qsize() < 1000:
+            consumer.resume(*consumer.paused())
+    logger.info("consume_loop_stopped")
+
+
+async def process_loop(
+    consumer: AIOKafkaConsumer,
+    producer: AIOKafkaProducer,
+    queue: asyncio.Queue,
+    stop_event: asyncio.Event,
+    logger: structlog.BoundLogger,
+) -> None:
+    while not stop_event.is_set() or not queue.empty():
+        msg = await queue.get()
+        try:
+            await process_kafka_message(msg, producer, consumer._group_id, logger)
+        except Exception as e:
+            logger.error("process_error", error=str(e))
+        finally:
+            queue.task_done()
+            QUEUE_GAUGE.set(queue.qsize())
+    logger.info("process_loop_stopped")
+
+
+async def shutdown(
+    consumer: AIOKafkaConsumer,
+    producer: AIOKafkaProducer,
+    runner: web.AppRunner,
+    stop_event: asyncio.Event,
+    tasks: Tuple[asyncio.Task, ...],
+    logger: structlog.BoundLogger,
+) -> None:
+    stop_event.set()
+    for t in tasks:
+        t.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+    await consumer.stop()
+    await producer.stop()
+    await runner.cleanup()
+    logger.info("shutdown_complete")
+
+
+async def main() -> None:
+    settings = Settings()
+    logger = configure_logging(settings.ENVIRONMENT)
+
+    consumer = AIOKafkaConsumer(
+        "rau_events",
+        bootstrap_servers=settings.KAFKA_BOOTSTRAP_SERVERS,
+        group_id="ai-orchestrator",
+        enable_auto_commit=False,
+        isolation_level="read_committed",
+        security_protocol=settings.KAFKA_SECURITY_PROTOCOL,
+        sasl_mechanism=settings.KAFKA_SASL_MECHANISM,
+        sasl_plain_username=settings.KAFKA_USERNAME,
+        sasl_plain_password=settings.KAFKA_PASSWORD,
+        ssl_cafile=settings.KAFKA_SSL_CAFILE,
+    )
+
+    producer = AIOKafkaProducer(
+        bootstrap_servers=settings.KAFKA_BOOTSTRAP_SERVERS,
+        transactional_id="trustvault-ai",
+        security_protocol=settings.KAFKA_SECURITY_PROTOCOL,
+        sasl_mechanism=settings.KAFKA_SASL_MECHANISM,
+        sasl_plain_username=settings.KAFKA_USERNAME,
+        sasl_plain_password=settings.KAFKA_PASSWORD,
+        ssl_cafile=settings.KAFKA_SSL_CAFILE,
+    )
+
+    await consumer.start()
+    await producer.start()
+
+    runner = await metrics_app()
+
+    queue: asyncio.Queue = asyncio.Queue()
+    stop_event = asyncio.Event()
+
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, stop_event.set)
+
+    consume_task = asyncio.create_task(consume_loop(consumer, queue, stop_event, logger))
+    process_task = asyncio.create_task(process_loop(consumer, producer, queue, stop_event, logger))
+
+    try:
+        await stop_event.wait()
+    finally:
+        await shutdown(
+            consumer,
+            producer,
+            runner,
+            stop_event,
+            (consume_task, process_task),
+            logger,
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/ai_service/pipeline.py
+++ b/ai_service/pipeline.py
@@ -1,0 +1,9 @@
+import asyncio
+
+async def process_event(event: dict):
+    """Dummy pipeline processing; returns topic, value, headers."""
+    await asyncio.sleep(0)  # simulate async work
+    if event.get("bad_json"):
+        # for tests: event indicates should go to DLQ
+        return "rau_events_dlq", {"error": "bad"}, {"reason": "bad_event"}
+    return "alerts", event, {}

--- a/ai_service/settings.py
+++ b/ai_service/settings.py
@@ -1,0 +1,14 @@
+from pydantic import BaseSettings, Field
+from typing import Optional
+
+class Settings(BaseSettings):
+    KAFKA_BOOTSTRAP_SERVERS: str = Field(..., env="KAFKA_BOOTSTRAP_SERVERS")
+    KAFKA_USERNAME: Optional[str] = Field(None, env="KAFKA_USERNAME")
+    KAFKA_PASSWORD: Optional[str] = Field(None, env="KAFKA_PASSWORD")
+    KAFKA_SECURITY_PROTOCOL: str = Field("PLAINTEXT", env="KAFKA_SECURITY_PROTOCOL")
+    KAFKA_SASL_MECHANISM: Optional[str] = Field(None, env="KAFKA_SASL_MECHANISM")
+    KAFKA_SSL_CAFILE: Optional[str] = Field(None, env="KAFKA_SSL_CAFILE")
+    ENVIRONMENT: str = Field("dev", env="ENVIRONMENT")
+
+    class Config:
+        case_sensitive = False

--- a/tests/test_kafka_orchestrator.py
+++ b/tests/test_kafka_orchestrator.py
@@ -1,0 +1,149 @@
+import asyncio
+import json
+
+import sys
+import types
+import os
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+try:
+    from aiokafka.errors import KafkaError
+except Exception:  # pragma: no cover - fallback when aiokafka isn't installed
+    aiokafka = types.ModuleType("aiokafka")
+    errors = types.ModuleType("aiokafka.errors")
+    prometheus_client = types.ModuleType("prometheus_client")
+    aiohttp = types.ModuleType("aiohttp")
+    aiohttp.web = types.ModuleType("aiohttp.web")
+    aiohttp.web.Application = object
+    aiohttp.web.AppRunner = object
+    aiohttp.web.TCPSite = object
+    aiohttp.web.Response = object
+    aiohttp.web.Request = object
+    class DummyMetric:
+        def __init__(self, *a, **kw):
+            pass
+        def inc(self, *a, **k):
+            pass
+        def set(self, *a, **k):
+            pass
+
+    prometheus_client.Gauge = DummyMetric
+    prometheus_client.Counter = DummyMetric
+    prometheus_client.CONTENT_TYPE_LATEST = "text/plain"
+    prometheus_client.CollectorRegistry = object
+    prometheus_client.generate_latest = lambda *a, **kw: b""
+    structlog = types.ModuleType("structlog")
+    structlog.processors = types.SimpleNamespace(JSONRenderer=lambda: None)
+    structlog.BoundLogger = object
+    def get_logger():
+        class Logger:
+            def bind(self, **kw):
+                return self
+            def warning(self, *a, **k):
+                pass
+            def error(self, *a, **k):
+                pass
+        return Logger()
+    structlog.get_logger = get_logger
+    structlog.configure = lambda *a, **k: None
+    pydantic = types.ModuleType("pydantic")
+    class BaseSettings:
+        pass
+    class Field:
+        def __init__(self, default=None, env=None):
+            pass
+    pydantic.BaseSettings = BaseSettings
+    pydantic.Field = Field
+
+    class KafkaError(Exception):
+        pass
+
+    class Dummy:
+        def __init__(self, *a, **k):
+            pass
+
+    aiokafka.AIOKafkaProducer = Dummy
+    aiokafka.AIOKafkaConsumer = Dummy
+    aiokafka.TopicPartition = Dummy
+    aiokafka.OffsetAndMetadata = Dummy
+    errors.KafkaError = KafkaError
+    sys.modules.setdefault("aiokafka", aiokafka)
+    sys.modules.setdefault("aiokafka.errors", errors)
+    sys.modules.setdefault("prometheus_client", prometheus_client)
+    sys.modules.setdefault("aiohttp", aiohttp)
+    sys.modules.setdefault("structlog", structlog)
+    sys.modules.setdefault("pydantic", pydantic)
+
+from ai_service.kafka_orchestrator import process_kafka_message
+
+
+class KafkaMockProducer:
+    def __init__(self, fail_first=False):
+        self.fail_first = fail_first
+        self.calls = 0
+        self.sent = []
+        self.offsets = []
+        self.aborted = 0
+        self.commits = 0
+
+    def begin_transaction(self):
+        pass
+
+    async def send_and_wait(self, topic, value, headers=None):
+        self.calls += 1
+        if self.fail_first and self.calls == 1:
+            raise KafkaError("temporary error")
+        self.sent.append((topic, value, headers))
+
+    async def send_offsets_to_transaction(self, offsets, group_id):
+        self.offsets.append((offsets, group_id))
+
+    async def commit_transaction(self):
+        self.commits += 1
+
+    async def abort_transaction(self):
+        self.aborted += 1
+
+
+class Message:
+    def __init__(self, value, topic="rau_events", partition=0, offset=0):
+        self.value = value
+        self.topic = topic
+        self.partition = partition
+        self.offset = offset
+
+
+class KafkaMockConsumer:
+    def __init__(self, group_id="test-group"):
+        self._group_id = group_id
+
+
+class DummyLogger:
+    def warning(self, *a, **k):
+        pass
+
+    def error(self, *a, **k):
+        pass
+
+
+def test_at_least_once_delivery():
+    producer = KafkaMockProducer(fail_first=True)
+    consumer = KafkaMockConsumer()
+    msg = Message(json.dumps({"foo": "bar"}).encode())
+    asyncio.run(process_kafka_message(msg, producer, consumer._group_id, DummyLogger()))
+    assert len(producer.sent) == 1
+    assert producer.commits == 1
+    assert producer.aborted == 1
+
+
+def test_bad_json_to_dlq():
+    producer = KafkaMockProducer()
+    consumer = KafkaMockConsumer()
+    bad = Message(b"not-json")
+    asyncio.run(process_kafka_message(bad, producer, consumer._group_id, DummyLogger()))
+    topic, value, headers = producer.sent[0]
+    assert topic == "rau_events_dlq"
+    assert value == b"not-json"
+    assert headers == [("reason", b"deserialization_error")]


### PR DESCRIPTION
## Summary
- add a new `ai_service` package with Kafka orchestrator
- implement minimal pipeline and settings
- create tests using `KafkaMock` fixtures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869cb34b478832cac06b491570f6481