### PR TITLE
Implement Kafka orchestrator with tests

### DIFF
--- a/ai_service/kafka_orchestrator.py
+++ b/ai_service/kafka_orchestrator.py
@@ -1,0 +1,191 @@
+"""Kafka Consumer and Orchestrator for AI service."""
+from __future__ import annotations
+
+import asyncio
+import json
+import signal
+from typing import Any, Dict, List, Optional, Set
+
+from aiokafka import AIOKafkaConsumer, AIOKafkaProducer, ConsumerRecord
+from aiokafka.structs import OffsetAndMetadata, TopicPartition
+from prometheus_client import Counter, Gauge, start_http_server
+from pydantic import BaseModel
+import structlog
+
+from .settings import get_settings, Settings
+
+
+logger = structlog.get_logger().bind(phase="ai-service", component="orchestrator")
+
+
+class NormalizedEvent(BaseModel):
+    """Normalized representation of an incoming event."""
+
+    id: str
+    payload: Dict[str, Any]
+
+
+class ScoreResult(BaseModel):
+    """Score produced by scoring engine."""
+
+    score: float
+
+
+class GPTLabel(BaseModel):
+    """Label produced by GPT model."""
+
+    label: str
+
+
+# Metrics
+PROCESSED_TOTAL = Counter("processed_total", "Total processed messages")
+FAILURES_TOTAL = Counter("failures_total", "Total failed messages")
+CONSUMER_LAG = Gauge("consumer_lag", "Current consumer lag")
+
+
+async def normalize_event(raw: Dict[str, Any]) -> NormalizedEvent:
+    """Stub normalizer that wraps the raw payload."""
+
+    return NormalizedEvent(id=str(raw.get("id", "unknown")), payload=raw)
+
+
+async def score_event(event: NormalizedEvent) -> ScoreResult:
+    """Stub scoring engine."""
+
+    # Example scoring logic
+    return ScoreResult(score=0.5)
+
+
+async def label_event(event: NormalizedEvent, score: ScoreResult) -> GPTLabel:
+    """Stub GPT labeler."""
+
+    return GPTLabel(label="ok")
+
+
+async def emit_alert(event: NormalizedEvent, score: ScoreResult, label: GPTLabel) -> None:
+    """Stub alert emitter."""
+
+    logger.info("Alert emitted", event_id=event.id, score=score.score, label=label.label)
+
+
+async def _handle_message(
+    record: ConsumerRecord,
+    consumer: AIOKafkaConsumer,
+    producer: AIOKafkaProducer,
+    settings: Settings,
+) -> None:
+    """Process a single Kafka record."""
+
+    tp = TopicPartition(record.topic, record.partition)
+    try:
+        raw = json.loads(record.value.decode("utf-8"))
+    except Exception:
+        logger.exception("Deserialization error")
+        await producer.begin_transaction()
+        await producer.send(
+            settings.dlq_topic,
+            record.value,
+            headers=[("reason", b"deserialization_error")],
+        )
+        await producer.send_offsets_to_transaction({tp: OffsetAndMetadata(record.offset + 1, None)}, settings.group_id)
+        await producer.commit_transaction()
+        FAILURES_TOTAL.inc()
+        return
+
+    await producer.begin_transaction()
+    try:
+        normalized = await normalize_event(raw)
+        scored = await score_event(normalized)
+        label = await label_event(normalized, scored)
+        await emit_alert(normalized, scored, label)
+        await producer.send(
+            settings.output_topic,
+            json.dumps({"id": normalized.id, "score": scored.score, "label": label.label}).encode(),
+        )
+
+        await producer.send_offsets_to_transaction({tp: OffsetAndMetadata(record.offset + 1, None)}, settings.group_id)
+        await producer.commit_transaction()
+        PROCESSED_TOTAL.inc()
+    except Exception:
+        logger.exception("Processing failed")
+        await producer.abort_transaction()
+        FAILURES_TOTAL.inc()
+
+    # update lag metric
+    highwater = consumer.highwater(tp)
+    if highwater is not None:
+        lag = highwater - record.offset - 1
+        CONSUMER_LAG.set(max(lag, 0))
+
+
+async def _consumer_loop(consumer: AIOKafkaConsumer, producer: AIOKafkaProducer, settings: Settings, stop_event: asyncio.Event) -> None:
+    """Consume messages from Kafka and process them."""
+
+    in_flight: Set[asyncio.Task[None]] = set()
+
+    while not stop_event.is_set():
+        try:
+            record = await asyncio.wait_for(consumer.getone(), timeout=1.0)
+        except asyncio.TimeoutError:
+            record = None
+        if record is None:
+            continue
+
+        task = asyncio.create_task(
+            _handle_message(record, consumer, producer, settings)
+        )
+        in_flight.add(task)
+        task.add_done_callback(lambda t: in_flight.discard(t))
+
+        if len(in_flight) > 10000:
+            for tp in consumer.assignment():
+                consumer.pause(tp)
+        elif len(in_flight) < 1000:
+            for tp in consumer.paused():
+                consumer.resume(tp)
+
+    # wait for outstanding tasks
+    if in_flight:
+        await asyncio.wait(in_flight)
+
+
+async def main() -> None:
+    """Entry point for running the orchestrator."""
+
+    settings = get_settings()
+    structlog.configure(processors=[structlog.processors.JSONRenderer()])
+
+    start_http_server(8001)
+
+    consumer = AIOKafkaConsumer(
+        settings.input_topic,
+        bootstrap_servers=settings.kafka_bootstrap_servers,
+        group_id=settings.group_id,
+        enable_auto_commit=False,
+    )
+
+    producer = AIOKafkaProducer(
+        bootstrap_servers=settings.kafka_bootstrap_servers,
+        transactional_id="ai-service-txn",
+    )
+
+    await consumer.start()
+    await producer.start()
+    await producer.init_transactions()
+
+    stop_event = asyncio.Event()
+
+    loop = asyncio.get_running_loop()
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, stop_event.set)
+
+    try:
+        await _consumer_loop(consumer, producer, settings, stop_event)
+    finally:
+        await producer.stop()
+        await consumer.stop()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    asyncio.run(main())

--- a/ai_service/settings.py
+++ b/ai_service/settings.py
@@ -1,0 +1,19 @@
+from functools import lru_cache
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Configuration for Kafka orchestrator."""
+
+    kafka_bootstrap_servers: str = Field("localhost:9092", alias="KAFKA_BOOTSTRAP_SERVERS")
+    group_id: str = Field("ai-service", alias="KAFKA_GROUP_ID")
+    input_topic: str = Field("rau_events", alias="KAFKA_INPUT_TOPIC")
+    dlq_topic: str = Field("rau_events_dlq", alias="KAFKA_DLQ_TOPIC")
+    output_topic: str = Field("alerts", alias="KAFKA_OUTPUT_TOPIC")
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Return cached application settings."""
+    return Settings()

--- a/tests/test_kafka_orchestrator.py
+++ b/tests/test_kafka_orchestrator.py
@@ -1,0 +1,112 @@
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import List
+
+# Ensure project root is on the path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+from aiokafka.structs import ConsumerRecord, TopicPartition
+
+from ai_service import kafka_orchestrator as ko
+from ai_service.settings import get_settings
+
+
+class KafkaMockProducer:
+    def __init__(self):
+        self.sent: List[tuple] = []
+        self.offsets = []
+
+    async def start(self):
+        pass
+
+    async def stop(self):
+        pass
+
+    async def init_transactions(self):
+        pass
+
+    async def begin_transaction(self):
+        pass
+
+    async def send(self, topic, value, headers=None):
+        self.sent.append((topic, value, headers))
+
+    async def send_offsets_to_transaction(self, offsets, group_id):
+        self.offsets.append(offsets)
+
+    async def commit_transaction(self):
+        pass
+
+    async def abort_transaction(self):
+        pass
+
+
+class KafkaMockConsumer:
+    def __init__(self, records):
+        self.records = records
+        self._assignment = {TopicPartition("rau_events", 0)}
+        self._paused = set()
+
+    async def start(self):
+        pass
+
+    async def stop(self):
+        pass
+
+    def highwater(self, tp):
+        return len(self.records)
+
+    async def getone(self):
+        if not self.records:
+            raise asyncio.TimeoutError()
+        return self.records.pop(0)
+
+    def assignment(self):
+        return self._assignment
+
+    def paused(self):
+        return self._paused
+
+    def pause(self, tp):
+        self._paused.add(tp)
+
+    def resume(self, tp):
+        self._paused.discard(tp)
+
+
+@pytest.fixture
+def kafka_mock(monkeypatch):
+    record = ConsumerRecord(
+        topic="rau_events",
+        partition=0,
+        offset=0,
+        timestamp=0,
+        timestamp_type=0,
+        key=None,
+        value=json.dumps({"id": "1"}).encode(),
+        checksum=None,
+        serialized_key_size=0,
+        serialized_value_size=0,
+        headers=[],
+    )
+    consumer = KafkaMockConsumer([record])
+    producer = KafkaMockProducer()
+
+    monkeypatch.setattr(ko, "AIOKafkaConsumer", lambda *a, **k: consumer)
+    monkeypatch.setattr(ko, "AIOKafkaProducer", lambda *a, **k: producer)
+
+    return consumer, producer
+
+
+@pytest.mark.asyncio
+async def test_at_least_once(kafka_mock):
+    consumer, producer = kafka_mock
+    settings = get_settings()
+
+    await ko._handle_message(await consumer.getone(), consumer, producer, settings)
+
+    assert producer.sent, "Message should be produced at least once"
+    assert producer.offsets, "Offset should be committed"


### PR DESCRIPTION
## Summary
- add `ai_service` package with Kafka orchestrator implementation
- support settings via pydantic BaseSettings
- expose metrics and structured logs
- include pytest covering at-least-once semantics
