### PR TITLE
Implement GPT-4o Labeler

### DIFF
--- a/ai_service/app/labeler.py
+++ b/ai_service/app/labeler.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Tuple
+
+import openai
+from pydantic import BaseModel, Field, ConfigDict
+from tenacity import retry, wait_exponential, stop_after_attempt
+import structlog
+import ulid
+
+from .normalize import NormalizedEvent
+from .scoring_engine import ScoreResult
+from .secrets_manager import get_openai_api_key
+
+
+class GPTLabel(BaseModel):
+    class_: str = Field(..., alias="class")
+    severity: str
+    reason: str
+    gpt_tokens: int
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+# configure logging
+structlog.configure(processors=[structlog.processors.JSONRenderer()])
+logger = structlog.get_logger().bind(service="gpt-labeler")
+
+
+def _score_to_severity(score: float) -> str:
+    if score >= 0.90:
+        return "Critical"
+    if score >= 0.75:
+        return "High"
+    if score >= 0.50:
+        return "Medium"
+    return "Low"
+
+
+# hard-coded results for mock mode
+_MOCK_LABELS: Tuple[Tuple[str, str], ...] = (
+    ("Account Compromise", "Critical"),
+    ("Data Exfiltration", "High"),
+    ("Malware", "Medium"),
+    ("Benign", "Low"),
+)
+
+
+def _mock_label(event: NormalizedEvent) -> Tuple[str, str]:
+    idx = ulid.from_str(event.id).int % len(_MOCK_LABELS)
+    return _MOCK_LABELS[idx]
+
+
+@retry(wait=wait_exponential(min=2, max=20), stop=stop_after_attempt(5),
+       retry=(lambda exc: isinstance(exc, (openai.RateLimitError, openai.APIError, openai.Timeout))))
+def _call_openai(messages: list[dict]) -> openai.types.chat.chat_completion.ChatCompletion:
+    api_key = get_openai_api_key()
+    return openai.ChatCompletion.create(model="gpt-4o-mini", temperature=0, messages=messages, api_key=api_key)
+
+
+def label_event(event: NormalizedEvent, scores: ScoreResult) -> GPTLabel:
+    if os.getenv("OPENAI_MOCK") == "1":
+        class_, severity = _mock_label(event)
+        logger.info("labeled", event_id=event.id, severity=severity, gpt_tokens=0, mock=True)
+        return GPTLabel(class_=class_, severity=severity, reason="Mock mode", gpt_tokens=0)
+
+    sev = _score_to_severity(scores.aggregate)
+
+    messages = [
+        {
+            "role": "system",
+            "content": "You are a senior SOC analyst. Respond with concise JSON {class, severity, reason}. No extra keys.",
+        },
+        {"role": "user", "content": json.dumps({"event": event.model_dump(mode="json"), "scores": scores.__dict__})},
+    ]
+
+    response = _call_openai(messages)
+    content = response["choices"][0]["message"]["content"]
+    try:
+        parsed = json.loads(content)
+    except Exception:
+        parsed = {"class": "Unknown", "reason": "Invalid GPT response"}
+
+    gpt_tokens = int(response.get("usage", {}).get("total_tokens", 0))
+    result = GPTLabel(class_=parsed.get("class", "Unknown"), severity=sev, reason=parsed.get("reason", ""), gpt_tokens=gpt_tokens)
+    logger.info("labeled", event_id=event.id, severity=sev, gpt_tokens=gpt_tokens, mock=False)
+    return result

--- a/ai_service/app/secrets_manager.py
+++ b/ai_service/app/secrets_manager.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import os
+import boto3
+
+_CACHE: str | None = None
+
+
+def get_openai_api_key() -> str:
+    global _CACHE
+    if _CACHE:
+        return _CACHE
+    region = os.getenv("AWS_REGION") or boto3.session.Session().region_name
+    client = boto3.client("secretsmanager", region_name=region)
+    resp = client.get_secret_value(SecretId="openai/api_key")
+    _CACHE = resp["SecretString"]
+    return _CACHE

--- a/ai_service/settings.py
+++ b/ai_service/settings.py
@@ -1,4 +1,5 @@
-from pydantic import BaseSettings, Field
+from pydantic import Field
+from pydantic_settings import BaseSettings
 from typing import Optional
 
 class Settings(BaseSettings):

--- a/tests/test_gpt_labeler.py
+++ b/tests/test_gpt_labeler.py
@@ -1,0 +1,60 @@
+import os
+import json
+import sys
+import importlib
+
+import pytest
+import openai
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# ensure real structlog is loaded
+mod = sys.modules.get("structlog")
+if mod is not None and getattr(mod, "__file__", None) is None:
+    sys.modules.pop("structlog", None)
+    importlib.invalidate_caches()
+import structlog  # noqa: F401
+
+from ai_service.app.labeler import label_event, GPTLabel
+from ai_service.app.normalize import Normalizer
+from ai_service.app.scoring_engine import ScoreResult
+
+
+@pytest.fixture
+def patch_openai(monkeypatch):
+    calls = []
+
+    def fake_create(*args, **kwargs):
+        calls.append((args, kwargs))
+        content = json.dumps({"class": "Account Compromise", "severity": "Low", "reason": "test"})
+        return {"choices": [{"message": {"content": content}}], "usage": {"total_tokens": 99}}
+
+    monkeypatch.setattr(openai.ChatCompletion, "create", fake_create)
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setattr("ai_service.app.labeler.get_openai_api_key", lambda: "sk-test")
+    return calls
+
+
+def test_mock_mode(monkeypatch, patch_openai):
+    monkeypatch.setenv("OPENAI_MOCK", "1")
+    raw = {"src_ip": "1.1.1.1", "timestamp": 0, "id": "01BX5ZZKBKACTAV9WEVGEMMVRZ"}
+    event = Normalizer.normalize(raw)
+    scores = ScoreResult(0.1, 0.1, 0.1)
+    res = label_event(event, scores)
+    assert isinstance(res, GPTLabel)
+    assert res.gpt_tokens == 0
+    assert res.reason == "Mock mode"
+    assert not patch_openai  # should not be called
+
+
+def test_real_call(monkeypatch, patch_openai):
+    monkeypatch.delenv("OPENAI_MOCK", raising=False)
+    raw = {"src_ip": "2.2.2.2", "timestamp": 0, "id": "01BX5ZZKBKACTAV9WEVGEMMVRZ"}
+    event = Normalizer.normalize(raw)
+    scores = ScoreResult(0.5, 0.5, 0.85)
+    res = label_event(event, scores)
+    assert res.class_ == "Account Compromise"
+    assert res.severity == "High"  # from score 0.85
+    assert res.reason == "test"
+    assert res.gpt_tokens == 99
+    assert patch_openai  # called


### PR DESCRIPTION
## Summary
- add GPT labeler using GPT-4o Mini
- include AWS Secrets Manager helper for API key
- update settings to use `pydantic-settings`
- provide tests for labeler behaviour
