### PR TITLE
Implement AlertEmitter with transactional Postgres + Kafka

### DIFF
--- a/ai_service/app/alert_emitter.py
+++ b/ai_service/app/alert_emitter.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+import time
+import uuid
+
+import asyncpg
+from confluent_kafka import Producer
+from pydantic import BaseModel
+import structlog
+
+from .normalize import NormalizedEvent
+from .scoring_engine import ScoreResult
+from .labeler import GPTLabel
+from .metrics import DB_LATENCY_SECONDS, KAFKA_PUBLISH_SECONDS, FAILED_TX_TOTAL
+from .secrets import get_db_dsn, get_kafka_conf
+
+
+class AlertIn(BaseModel):
+    event: NormalizedEvent
+    scores: ScoreResult
+    label: GPTLabel
+
+
+class AlertEmitter:
+    def __init__(self) -> None:
+        self._pool: asyncpg.Pool | None = None
+        self._stmt: asyncpg.PreparedStatement | None = None
+        self._producer: Producer | None = None
+        structlog.configure(processors=[structlog.processors.JSONRenderer()])
+        self._logger = structlog.get_logger().bind(service="alert-emitter")
+
+    # ------------------------------------------------------------------
+    async def init(self) -> None:
+        """Initialize DB pool and Kafka producer."""
+        dsn = get_db_dsn()
+        self._pool = await asyncpg.create_pool(dsn=dsn, min_size=1, max_size=4)
+        async with self._pool.acquire() as conn:
+            self._stmt = await conn.prepare(
+                """
+                INSERT INTO public.alerts (
+                    id, event_id, class, severity, reason, score,
+                    event_ts, raw, gpt_tokens
+                ) VALUES (
+                    $1, $2, $3, $4, $5, $6, $7, $8, $9
+                ) ON CONFLICT (event_id) DO NOTHING RETURNING id
+                """
+            )
+        conf = {
+            **get_kafka_conf(),
+            "transactional.id": "trustvault-alert-emitter",
+            "enable.idempotence": True,
+            "acks": "all",
+            "linger.ms": 10,
+            "compression.type": "zstd",
+        }
+        self._producer = Producer(conf)
+        self._producer.init_transactions()
+
+    async def close(self) -> None:
+        if self._producer is not None:
+            try:
+                self._producer.flush(5000)
+            except Exception:
+                pass
+            self._producer = None
+        if self._pool is not None:
+            await self._pool.close()
+            self._pool = None
+
+    # ------------------------------------------------------------------
+    async def emit(self, alert: AlertIn) -> None:
+        assert self._producer is not None and self._pool is not None
+        producer = self._producer
+        pool = self._pool
+        key = alert.event.id.encode()
+        payload = {
+            "event": alert.event.model_dump(mode="json"),
+            "scores": alert.scores.__dict__,
+            "label": alert.label.model_dump(by_alias=True),
+        }
+        value = json.dumps(payload, separators=(",", ":")).encode()
+        alert_id = str(uuid.uuid4())
+        logger = self._logger.bind(alert_id=alert_id, severity=alert.label.severity)
+
+        producer.begin_transaction()
+        inserted = False
+        try:
+            db_start = time.perf_counter()
+            async with pool.acquire() as conn:
+                res = await conn.fetchval(
+                    self._stmt,
+                    alert_id,
+                    alert.event.id,
+                    alert.label.class_,
+                    alert.label.severity,
+                    alert.label.reason,
+                    alert.scores.aggregate,
+                    alert.event.timestamp,
+                    json.dumps(alert.event.model_dump(mode="json"), separators=(",", ":")),
+                    alert.label.gpt_tokens,
+                )
+            inserted = res is not None
+            DB_LATENCY_SECONDS.labels(outcome="success").observe(time.perf_counter() - db_start)
+        except Exception:
+            DB_LATENCY_SECONDS.labels(outcome="failure").observe(time.perf_counter() - db_start)
+            FAILED_TX_TOTAL.labels(stage="db").inc()
+            producer.abort_transaction()
+            await self._send_dlq(key, value, reason="db_failure")
+            logger.error("db_error", tx_state="aborted")
+            return
+
+        try:
+            k_start = time.perf_counter()
+            producer.produce("alerts", key=key, value=value)
+            producer.commit_transaction()
+            KAFKA_PUBLISH_SECONDS.labels(outcome="success").observe(time.perf_counter() - k_start)
+            logger.info("emitted", tx_state="committed")
+        except Exception:
+            KAFKA_PUBLISH_SECONDS.labels(outcome="failure").observe(time.perf_counter() - k_start)
+            FAILED_TX_TOTAL.labels(stage="kafka").inc()
+            producer.abort_transaction()
+            if inserted:
+                async with pool.acquire() as conn:
+                    await conn.execute("DELETE FROM public.alerts WHERE event_id=$1", alert.event.id)
+            await self._send_dlq(key, value, reason="kafka_failure")
+            logger.error("kafka_error", tx_state="aborted")
+
+    async def _send_dlq(self, key: bytes, value: bytes, *, reason: str) -> None:
+        try:
+            assert self._producer is not None
+            self._producer.produce(
+                "alerts_dlq",
+                key=key,
+                value=value,
+                headers=[("reason", reason.encode())],
+            )
+            self._producer.flush()
+        except Exception:
+            pass
+
+
+# module level singleton
+emitter = AlertEmitter()

--- a/ai_service/app/metrics.py
+++ b/ai_service/app/metrics.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from prometheus_client import Histogram, Counter, start_http_server
+
+# Metrics definitions
+DB_LATENCY_SECONDS = Histogram(
+    "db_latency_seconds",
+    "Database operation latency",
+    ["outcome"],
+    buckets=[0.005, 0.01, 0.05, 0.1, 0.5],
+)
+KAFKA_PUBLISH_SECONDS = Histogram(
+    "kafka_publish_seconds",
+    "Kafka publish latency",
+    ["outcome"],
+    buckets=[0.005, 0.01, 0.05, 0.1],
+)
+FAILED_TX_TOTAL = Counter(
+    "failed_tx_total",
+    "Failed transactions",
+    ["stage"],
+)
+
+
+def start_metrics_server(port: int = 9103) -> None:
+    """Start Prometheus metrics HTTP server."""
+    try:
+        start_http_server(port)
+    except Exception:
+        # ignore errors in restricted environments
+        pass
+
+
+# start metrics server on import
+start_metrics_server()

--- a/ai_service/app/secrets.py
+++ b/ai_service/app/secrets.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+import os
+from functools import lru_cache
+
+
+@lru_cache(maxsize=None)
+def get_db_dsn() -> str:
+    """Return Postgres DSN from environment or defaults."""
+    dsn = os.getenv("DATABASE_DSN")
+    if dsn:
+        return dsn
+    secret_json = os.getenv("DB_SECRET_JSON")
+    if secret_json:
+        try:
+            return json.loads(secret_json)["dsn"]
+        except Exception:
+            pass
+    return "postgresql://postgres:postgres@localhost/postgres"
+
+
+@lru_cache(maxsize=None)
+def get_kafka_conf() -> dict[str, str]:
+    """Return Kafka configuration dictionary."""
+    conf_env = os.getenv("KAFKA_CONF_JSON")
+    if conf_env:
+        try:
+            return json.loads(conf_env)
+        except Exception:
+            pass
+    bootstrap = os.getenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+    return {"bootstrap.servers": bootstrap}

--- a/tests/test_alert_emitter.py
+++ b/tests/test_alert_emitter.py
@@ -1,0 +1,133 @@
+import sys
+import os
+import asyncio
+import json
+import datetime as dt
+from unittest.mock import patch
+
+import pytest
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from ai_service.app.alert_emitter import AlertEmitter, AlertIn
+from ai_service.app.normalize import NormalizedEvent
+from ai_service.app.scoring_engine import ScoreResult
+from ai_service.app.labeler import GPTLabel
+
+pytestmark = pytest.mark.asyncio
+
+
+class DummyProducer:
+    def __init__(self):
+        self.messages = []
+        self.transactions = []
+        self.fail_commit = False
+
+    def init_transactions(self):
+        pass
+
+    def begin_transaction(self):
+        self.transactions.append("begin")
+
+    def produce(self, topic, key=None, value=None, headers=None):
+        self.messages.append((topic, value, headers))
+
+    def commit_transaction(self):
+        if self.fail_commit:
+            raise RuntimeError("commit failure")
+        self.transactions.append("commit")
+
+    def abort_transaction(self):
+        self.transactions.append("abort")
+
+    def flush(self, timeout=None):
+        pass
+
+
+class DummyConn:
+    def __init__(self, pool):
+        self.pool = pool
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def execute(self, *args, **kw):
+        self.pool.rows.append(args)
+
+    async def fetchval(self, *args, **kw):
+        self.pool.rows.append(args)
+        return "id"
+
+
+class DummyPool:
+    def __init__(self):
+        self.rows = []
+
+    def acquire(self):
+        return DummyConn(self)
+
+    async def close(self):
+        pass
+
+
+async def _example_alert():
+    event = NormalizedEvent(id="01BX5ZZKBKACTAV9WEVGEMMVRZ", src_ip="1.1.1.1", timestamp=dt.datetime.utcnow(), is_internal=True)
+    scores = ScoreResult(score_if=0.1, score_lstm=0.2, aggregate=0.3)
+    label = GPTLabel(class_="Test", severity="Low", reason="", gpt_tokens=0)
+    return AlertIn(event=event, scores=scores, label=label)
+
+
+async def test_success(monkeypatch):
+    emitter = AlertEmitter()
+    emitter._pool = DummyPool()
+    prod = DummyProducer()
+    emitter._producer = prod
+    emitter._stmt = object()
+
+    alert = await _example_alert()
+    await emitter.emit(alert)
+
+    assert prod.transactions == ["begin", "commit"]
+    topic, value, _hdr = prod.messages[0]
+    assert topic == "alerts"
+
+
+async def test_kafka_failure(monkeypatch):
+    emitter = AlertEmitter()
+    emitter._pool = DummyPool()
+    prod = DummyProducer()
+    prod.fail_commit = True
+    emitter._producer = prod
+    emitter._stmt = object()
+
+    alert = await _example_alert()
+    await emitter.emit(alert)
+
+    assert "abort" in prod.transactions
+    topic, value, hdr = prod.messages[-1]
+    assert topic == "alerts_dlq"
+
+
+async def test_db_failure(monkeypatch):
+    class FailPool(DummyPool):
+        def acquire(self):
+            class Conn(DummyConn):
+                async def fetchval(self, *a, **kw):
+                    raise Exception("db error")
+
+            return Conn(self)
+
+    emitter = AlertEmitter()
+    emitter._pool = FailPool()
+    prod = DummyProducer()
+    emitter._producer = prod
+    emitter._stmt = object()
+
+    alert = await _example_alert()
+    await emitter.emit(alert)
+
+    assert "abort" in prod.transactions
+    topic, value, hdr = prod.messages[-1]
+    assert topic == "alerts_dlq"


### PR DESCRIPTION
## Summary
- add AlertEmitter component with transactional publishing and DB writes
- expose Prometheus metrics and secrets helpers
- provide basic unit tests for AlertEmitter

