### PR TITLE
Add sessions API with tests

### DIFF
--- a/iam-service/package-lock.json
+++ b/iam-service/package-lock.json
@@ -18,7 +18,9 @@
         "json-logic-js": "^2.0.2",
         "node-fetch": "^3.3.2",
         "prom-client": "^14.1.1",
-        "speakeasy": "^2.0.0"
+        "speakeasy": "^2.0.0",
+        "structlog": "^1.0.5",
+        "zod": "^3.22.4"
       },
       "devDependencies": {
         "@types/express": "^4.17.21",
@@ -6702,6 +6704,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/structlog": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/structlog/-/structlog-1.0.5.tgz",
+      "integrity": "sha512-0iJM9+hLfKgDEv+r7j1kAt1le3RDsGN5O4douo8svJ4U/bNyH5Xwdn2wuNdT2X1Itr8k/V1FturT7RekRGrVqw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/superagent": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
@@ -7284,6 +7295,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.74",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.74.tgz",
+      "integrity": "sha512-J8poo92VuhKjNknViHRAIuuN6li/EwFbAC8OedzI8uxpEPGiXHGQu9wemIAioIpqgfB4SySaJhdk0mH5Y4ICBg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/iam-service/package.json
+++ b/iam-service/package.json
@@ -16,6 +16,8 @@
     "fastify": "^4.29.1",
     "ioredis": "^5.3.2",
     "json-logic-js": "^2.0.2",
+    "zod": "^3.22.4",
+    "structlog": "^1.0.5",
     "node-fetch": "^3.3.2",
     "prom-client": "^14.1.1",
     "speakeasy": "^2.0.0"

--- a/iam-service/src/middleware/authz.ts
+++ b/iam-service/src/middleware/authz.ts
@@ -77,6 +77,7 @@ export async function authzMiddleware(req: Request, res: Response, next: NextFun
   let payload: any;
   try {
     payload = await jwt.verify(auth.slice(7));
+    (req as any).user = payload;
   } catch (e) {
     authzDenied.inc({ reason: 'jwt_invalid' });
     return res.status(403).json({ error: 'Forbidden', reason: 'jwt_invalid' });

--- a/iam-service/src/routes/sessions.ts
+++ b/iam-service/src/routes/sessions.ts
@@ -1,0 +1,126 @@
+import express, { Express, Request, Response } from 'express';
+import { PrismaClient } from '@prisma/client';
+import Redis from 'ioredis';
+import { z } from 'zod';
+import { Counter } from 'prom-client';
+import { logger } from 'structlog';
+import { attachAuthz } from '../middleware/authz';
+
+const prisma = new PrismaClient();
+
+const sessionRevoked = new Counter({
+  name: 'session_revoked_total',
+  help: 'Total sessions revoked',
+});
+
+const querySchema = z.object({
+  userId: z.string().optional(),
+  page: z.string().optional(),
+  pageSize: z
+    .preprocess((v) => (v === undefined ? undefined : Number(v)), z.number().int().min(1).max(100))
+    .optional()
+    .default(20),
+});
+
+/**
+ * @openapi
+ * /sessions:
+ *   get:
+ *     tags: [Sessions]
+ *     responses:
+ *       200: {}
+ *       400: {}
+ *       403: {}
+ *       401: {}
+ */
+async function listSessions(req: Request, res: Response) {
+  const parsed = querySchema.safeParse(req.query);
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'Bad Request' });
+  }
+
+  const { userId, page, pageSize } = parsed.data;
+  const auth = (req as any).user || {};
+  const target = userId || auth.sub;
+  const isAdmin = Array.isArray(auth.roles) && auth.roles.includes('admin');
+
+  if (!isAdmin && target !== auth.sub) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  const where: any = { user_id: target };
+  if (page) {
+    const d = new Date(page);
+    if (isNaN(d.getTime())) return res.status(400).json({ error: 'Bad Request' });
+    where.created_at = { lt: d };
+  }
+
+  const list = await prisma.sessions.findMany({
+    where,
+    orderBy: { created_at: 'desc' },
+    take: pageSize + 1,
+  });
+
+  const next = list.length > pageSize ? list[pageSize].created_at.toISOString() : null;
+  const data = list.slice(0, pageSize).map((s: any) => ({
+    jti: s.jti,
+    ip: s.ip,
+    device: s.ua,
+    created_at: s.created_at.toISOString(),
+    last_seen: s.last_seen ? new Date(s.last_seen).toISOString() : null,
+    revoked: !!s.revoked,
+  }));
+
+  res.json({ data, next });
+}
+
+/**
+ * @openapi
+ * /sessions/{jti}:
+ *   delete:
+ *     tags: [Sessions]
+ *     responses:
+ *       204: {}
+ *       403: {}
+ *       404: {}
+ *       401: {}
+ */
+async function deleteSession(req: Request, res: Response) {
+  const { jti } = req.params;
+  if (!jti) return res.status(400).json({ error: 'Bad Request' });
+
+  const session = await prisma.sessions.findUnique({ where: { jti } });
+  if (!session) return res.status(404).end();
+
+  const auth = (req as any).user || {};
+  const isAdmin = Array.isArray(auth.roles) && auth.roles.includes('admin');
+  if (!isAdmin && auth.sub !== session.user_id) {
+    return res.status(403).end();
+  }
+
+  if (!session.revoked) {
+    const redis: Redis = req.app.locals.redis;
+    await redis.setex(`jwt:blacklist:${jti}`, 900, 'revoked');
+    await prisma.sessions.update({ where: { jti }, data: { revoked: true, revoked_at: new Date() } });
+    sessionRevoked.inc();
+    logger.info('session_revoked', { action: 'revoke', jti, user_id: session.user_id, by: auth.sub });
+  }
+
+  res.status(204).end();
+}
+
+export function mountSessionRoutes(app: Express) {
+  const router = express.Router();
+
+  router.use((req, res, next) => {
+    if (!req.headers.authorization) return res.status(401).json({ error: 'Unauthorized' });
+    next();
+  });
+  attachAuthz(router as unknown as Express);
+
+  router.get('/sessions', listSessions);
+  router.delete('/sessions/:jti', deleteSession);
+
+  app.use('/api', router);
+}
+

--- a/iam-service/src/types.d.ts
+++ b/iam-service/src/types.d.ts
@@ -8,3 +8,13 @@ declare module 'speakeasy';
 declare module 'json-logic-js' {
   export function apply(rule: any, data: any): any;
 }
+
+declare module 'structlog' {
+  export const logger: { info: (...args: any[]) => void };
+}
+
+declare namespace Express {
+  interface Request {
+    user?: any;
+  }
+}

--- a/iam-service/tests/sessions.test.ts
+++ b/iam-service/tests/sessions.test.ts
@@ -1,0 +1,179 @@
+import request from 'supertest';
+import express from 'express';
+import Redis from 'ioredis';
+
+// Minimal casbin mock
+jest.mock('casbin', () => {
+  return {
+    newEnforcer: jest.fn(async () => {
+      const enforcer: any = {
+        policies: new Set<string>(),
+        groups: new Map<string, Set<string>>()
+      };
+      enforcer.addPolicy = (role: string, path: string, method: string) => {
+        enforcer.policies.add(`${role}|${path}|${method}`);
+        return Promise.resolve(true);
+      };
+      enforcer.addGroupingPolicy = (sub: string, role: string) => {
+        if (!enforcer.groups.has(sub)) enforcer.groups.set(sub, new Set());
+        enforcer.groups.get(sub)!.add(role);
+        return Promise.resolve(true);
+      };
+      enforcer.clearPolicy = () => { enforcer.policies.clear(); return Promise.resolve(); };
+      enforcer.enforce = (sub: string, path: string, method: string) => {
+        const roles = enforcer.groups.get(sub) || new Set();
+        for (const r of roles) {
+          if (enforcer.policies.has(`${r}|${path}|${method}`)) return Promise.resolve(true);
+        }
+        return Promise.resolve(false);
+      };
+      return enforcer;
+    }),
+    newModelFromString: jest.fn(),
+    Enforcer: class {}
+  };
+});
+
+let mountSessionRoutes: any;
+let redisStore: Map<string, string>;
+let jwtPayload: any = {};
+
+const sessions: any[] = [];
+const rolePolicies: any[] = [];
+const abacRules: any[] = [];
+
+jest.mock('@prisma/client', () => {
+  return {
+    PrismaClient: jest.fn().mockImplementation(() => ({
+      sessions: {
+        findMany: jest.fn(({ where, orderBy, take }: any) => {
+          let list = sessions.filter(s => s.user_id === where.user_id);
+          if (where.created_at && where.created_at.lt) {
+            list = list.filter(s => s.created_at < where.created_at.lt);
+          }
+          list = list.sort((a,b) => b.created_at.getTime() - a.created_at.getTime());
+          if (take) list = list.slice(0, take);
+          return Promise.resolve(list);
+        }),
+        findUnique: jest.fn(({ where }: any) => Promise.resolve(sessions.find(s => s.jti === where.jti) || null)),
+        update: jest.fn(({ where, data }: any) => { const s = sessions.find(x => x.jti === where.jti)!; Object.assign(s, data); return Promise.resolve(s); }),
+      },
+      role_policies: {
+        findMany: jest.fn(() => Promise.resolve(rolePolicies))
+      },
+      attribute_rules: {
+        findMany: jest.fn(() => Promise.resolve(abacRules))
+      }
+    }))
+  };
+});
+
+redisStore = new Map();
+jest.mock('ioredis', () => {
+  return jest.fn().mockImplementation(() => ({
+    get: jest.fn((k: string) => Promise.resolve(redisStore.get(k) ?? null)),
+    set: jest.fn((k: string, v: string) => { redisStore.set(k, v); return Promise.resolve('OK'); }),
+    setex: jest.fn((k: string, ttl: number, v: string) => { redisStore.set(k, v); return Promise.resolve('OK'); })
+  }));
+});
+
+jest.mock('structlog', () => ({ logger: { info: jest.fn() } }), { virtual: true });
+
+jest.mock('@trustvault/jwt', () => ({ verify: jest.fn(() => Promise.resolve(jwtPayload)) }), { virtual: true });
+
+beforeEach(async () => {
+  jest.resetModules();
+  ({ mountSessionRoutes } = await import('../src/routes/sessions'));
+  redisStore.clear();
+  rolePolicies.length = 0;
+  abacRules.length = 0;
+  rolePolicies.push(
+    { role: 'user', path: '/sessions', method: 'get' },
+    { role: 'user', path: '/sessions/s1', method: 'delete' },
+    { role: 'user', path: '/sessions/s2', method: 'delete' },
+    { role: 'admin', path: '/sessions', method: 'get' },
+    { role: 'admin', path: '/sessions/s1', method: 'delete' },
+    { role: 'admin', path: '/sessions/s2', method: 'delete' },
+    { role: 'admin', path: '/sessions/s3', method: 'delete' }
+  );
+  sessions.length = 0;
+  sessions.push(
+    { jti: 's1', user_id: 'u1', ip: '1.2.3.4', ua: 'ua', created_at: new Date('2025-07-07T05:32:10Z'), last_seen: new Date('2025-07-07T06:10:05Z'), revoked: false, revoked_at: null },
+    { jti: 's2', user_id: 'u1', ip: '1.2.3.5', ua: 'ua2', created_at: new Date('2025-07-07T04:32:10Z'), last_seen: new Date('2025-07-07T05:10:05Z'), revoked: true, revoked_at: new Date('2025-07-07T06:00:00Z') },
+    { jti: 's3', user_id: 'u2', ip: '1.2.3.6', ua: 'ua3', created_at: new Date('2025-07-07T03:32:10Z'), last_seen: new Date('2025-07-07T04:10:05Z'), revoked: false, revoked_at: null },
+  );
+  Object.assign(jwtPayload, { sub: 'u1', jti: 't', roles: ['user'] });
+});
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.locals.redis = new Redis();
+  mountSessionRoutes(app);
+  return app;
+}
+
+describe('session routes', () => {
+  test('list own sessions', async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .get('/api/sessions')
+      .set('Authorization', 'Bearer token');
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBe(2);
+  });
+
+  test('list others forbidden', async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .get('/api/sessions')
+      .query({ userId: 'u2' })
+      .set('Authorization', 'Bearer token');
+    expect(res.status).toBe(403);
+  });
+
+  test('admin list others', async () => {
+    Object.assign(jwtPayload, { sub: 'admin', jti: 'a', roles: ['admin'] });
+    const app = makeApp();
+    const res = await request(app)
+      .get('/api/sessions')
+      .query({ userId: 'u2' })
+      .set('Authorization', 'Bearer token');
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].jti).toBe('s3');
+  });
+
+  test('delete own active session', async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .delete('/api/sessions/s1')
+      .set('Authorization', 'Bearer token');
+    expect(res.status).toBe(204);
+    expect(redisStore.get('jwt:blacklist:s1')).toBe('revoked');
+    expect(sessions.find(s => s.jti === 's1')!.revoked).toBe(true);
+  });
+
+  test('delete already revoked session', async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .delete('/api/sessions/s2')
+      .set('Authorization', 'Bearer token');
+    expect(res.status).toBe(204);
+    expect(redisStore.has('jwt:blacklist:s2')).toBe(false);
+  });
+
+  test('delete others session forbidden', async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .delete('/api/sessions/s3')
+      .set('Authorization', 'Bearer token');
+    expect(res.status).toBe(403);
+  });
+
+  test('auth missing', async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .get('/api/sessions');
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary
- implement Express sessions routes with pagination, revocation, OpenAPI docs
- enhance authz middleware to attach JWT payload
- extend type declarations
- add comprehensive Jest tests for session routes
- include zod and structlog packages
