### PR TITLE
Implement roles and rules routes with tests

### DIFF
--- a/iam-service/src/routes/roles.ts
+++ b/iam-service/src/routes/roles.ts
@@ -1,0 +1,101 @@
+import express, { Express, Request, Response } from 'express';
+import { PrismaClient } from '@prisma/client';
+import { z } from 'zod';
+
+const prisma = new PrismaClient();
+
+const createSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  permissions: z.array(z.string()),
+});
+
+const updateSchema = createSchema.partial();
+
+const querySchema = z.object({
+  search: z.string().optional(),
+  cursor: z.string().optional(),
+  limit: z
+    .preprocess((v) => (v === undefined ? 20 : Number(v)), z.number().int().min(1).max(100))
+    .optional()
+    .default(20),
+});
+
+async function listRoles(req: Request, res: Response) {
+  const parsed = querySchema.safeParse(req.query);
+  if (!parsed.success) return res.status(400).json({ error: 'Bad Request' });
+
+  const auth: any = (req as any).user || {};
+  const isAdmin = Array.isArray(auth.roles) && auth.roles.includes('admin');
+  const perms: string[] = auth.permissions || [];
+  if (!isAdmin && !perms.includes('iam:roles:read')) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  const { search, cursor, limit } = parsed.data;
+  const where: any = { deleted_at: null };
+  if (search) where.name = { contains: search, mode: 'insensitive' };
+  if (cursor) where.id = { gt: cursor };
+
+  const list = await prisma.role.findMany({
+    where,
+    orderBy: { id: 'asc' },
+    take: limit + 1,
+  });
+  const next = list.length > limit ? list[limit].id : null;
+  const data = list.slice(0, limit).map((r: any) => ({
+    id: r.id,
+    name: r.name,
+    description: r.description,
+    permissions: r.permissions,
+    created_at: r.created_at.toISOString(),
+  }));
+  res.json({ success: true, data: { items: data, next } });
+}
+
+async function createRole(req: Request, res: Response) {
+  const auth: any = (req as any).user || {};
+  if (!Array.isArray(auth.roles) || !auth.roles.includes('admin')) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  const parsed = createSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: 'Bad Request' });
+  const role = await prisma.role.create({ data: parsed.data });
+  await req.app.locals.kafka?.publish('role.updated', JSON.stringify(role));
+  res.json({ success: true, data: { ...role, created_at: role.created_at.toISOString() } });
+}
+
+async function updateRole(req: Request, res: Response) {
+  const auth: any = (req as any).user || {};
+  if (!Array.isArray(auth.roles) || !auth.roles.includes('admin')) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  const parsed = updateSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: 'Bad Request' });
+  const id = req.params.id;
+  const role = await prisma.role.update({ where: { id }, data: parsed.data });
+  await req.app.locals.kafka?.publish('role.updated', JSON.stringify(role));
+  res.json({ success: true, data: { ...role, created_at: role.created_at.toISOString() } });
+}
+
+async function deleteRole(req: Request, res: Response) {
+  const auth: any = (req as any).user || {};
+  if (!Array.isArray(auth.roles) || !auth.roles.includes('admin')) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  const id = req.params.id;
+  await prisma.role.update({ where: { id }, data: { deleted_at: new Date() } });
+  await req.app.locals.kafka?.publish('role.updated', JSON.stringify({ id, deleted: true }));
+  res.status(204).end();
+}
+
+export function mountRoleRoutes(app: Express) {
+  const router = express.Router();
+  router.get('/roles', listRoles);
+  router.post('/roles', createRole);
+  router.patch('/roles/:id', updateRole);
+  router.delete('/roles/:id', deleteRole);
+  app.use('/api', router);
+}
+
+export default mountRoleRoutes;

--- a/iam-service/src/routes/rules.ts
+++ b/iam-service/src/routes/rules.ts
@@ -1,0 +1,115 @@
+import express, { Express, Request, Response } from 'express';
+import { PrismaClient } from '@prisma/client';
+import { z } from 'zod';
+import { apply } from 'json-logic-js';
+
+const prisma = new PrismaClient();
+
+const createSchema = z.object({
+  name: z.string(),
+  target: z.string(),
+  json_logic: z.any(),
+});
+
+const updateSchema = createSchema.partial();
+
+const querySchema = z.object({
+  search: z.string().optional(),
+  cursor: z.string().optional(),
+  limit: z
+    .preprocess((v) => (v === undefined ? 20 : Number(v)), z.number().int().min(1).max(100))
+    .optional()
+    .default(20),
+});
+
+function validateLogic(rule: any): boolean {
+  try {
+    apply(rule, {});
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+async function listRules(req: Request, res: Response) {
+  const parsed = querySchema.safeParse(req.query);
+  if (!parsed.success) return res.status(400).json({ error: 'Bad Request' });
+
+  const auth: any = (req as any).user || {};
+  const isAdmin = Array.isArray(auth.roles) && auth.roles.includes('admin');
+  const perms: string[] = auth.permissions || [];
+  if (!isAdmin && !perms.includes('iam:rules:read')) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  const { search, cursor, limit } = parsed.data;
+  const where: any = { deleted_at: null };
+  if (search) where.name = { contains: search, mode: 'insensitive' };
+  if (cursor) where.id = { gt: cursor };
+
+  const list = await prisma.abacRule.findMany({
+    where,
+    orderBy: { id: 'asc' },
+    take: limit + 1,
+  });
+  const next = list.length > limit ? list[limit].id : null;
+  const data = list.slice(0, limit).map((r: any) => ({
+    id: r.id,
+    name: r.name,
+    target: r.target,
+    json_logic: r.json_logic,
+    created_at: r.created_at.toISOString(),
+  }));
+  res.json({ success: true, data: { items: data, next } });
+}
+
+async function createRule(req: Request, res: Response) {
+  const auth: any = (req as any).user || {};
+  if (!Array.isArray(auth.roles) || !auth.roles.includes('admin')) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  const parsed = createSchema.safeParse(req.body);
+  if (!parsed.success || !validateLogic(parsed.data.json_logic)) {
+    return res.status(400).json({ error: 'Bad Request' });
+  }
+  const rule = await prisma.abacRule.create({ data: parsed.data });
+  await req.app.locals.kafka?.publish('rule.updated', JSON.stringify(rule));
+  res.json({ success: true, data: { ...rule, created_at: rule.created_at.toISOString() } });
+}
+
+async function updateRule(req: Request, res: Response) {
+  const auth: any = (req as any).user || {};
+  if (!Array.isArray(auth.roles) || !auth.roles.includes('admin')) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  const parsed = updateSchema.safeParse(req.body);
+  if (!parsed.success || (parsed.data.json_logic && !validateLogic(parsed.data.json_logic))) {
+    return res.status(400).json({ error: 'Bad Request' });
+  }
+  const id = req.params.id;
+  const rule = await prisma.abacRule.update({ where: { id }, data: parsed.data });
+  await req.app.locals.kafka?.publish('rule.updated', JSON.stringify(rule));
+  res.json({ success: true, data: { ...rule, created_at: rule.created_at.toISOString() } });
+}
+
+async function deleteRule(req: Request, res: Response) {
+  const auth: any = (req as any).user || {};
+  if (!Array.isArray(auth.roles) || !auth.roles.includes('admin')) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  const id = req.params.id;
+  await prisma.abacRule.update({ where: { id }, data: { deleted_at: new Date() } });
+  await req.app.locals.kafka?.publish('rule.updated', JSON.stringify({ id, deleted: true }));
+  res.status(204).end();
+}
+
+export function mountRuleRoutes(app: Express) {
+  const router = express.Router();
+  router.get('/rules', listRules);
+  router.post('/rules', createRule);
+  router.patch('/rules/:id', updateRule);
+  router.delete('/rules/:id', deleteRule);
+  app.use('/api', router);
+}
+
+export default mountRuleRoutes;

--- a/iam-service/tests/roles.test.ts
+++ b/iam-service/tests/roles.test.ts
@@ -1,0 +1,78 @@
+import request from 'supertest';
+import express from 'express';
+
+let mountRoleRoutes: any;
+const roles: any[] = [];
+const published: any[] = [];
+
+jest.mock('@prisma/client', () => {
+  return {
+    PrismaClient: jest.fn().mockImplementation(() => ({
+      role: {
+        create: jest.fn(({ data }: any) => {
+          const r = { id: `r${roles.length + 1}`, created_at: new Date('2025-01-01T00:00:00Z'), deleted_at: null, ...data };
+          roles.push(r);
+          return Promise.resolve(r);
+        }),
+        update: jest.fn(({ where: { id }, data }: any) => {
+          const r = roles.find((x) => x.id === id)!;
+          Object.assign(r, data);
+          return Promise.resolve(r);
+        }),
+        findMany: jest.fn(({ where }: any) => {
+          let list = roles.filter((r) => r.deleted_at === null);
+          if (where?.name?.contains) {
+            list = list.filter((r) => r.name.includes(where.name.contains));
+          }
+          if (where?.id?.gt) {
+            list = list.filter((r) => r.id > where.id.gt);
+          }
+          return Promise.resolve(list);
+        }),
+      },
+    })),
+  };
+});
+
+beforeEach(async () => {
+  jest.resetModules();
+  roles.length = 0;
+  published.length = 0;
+  ({ mountRoleRoutes } = await import('../src/routes/roles'));
+});
+
+function makeApp(user: any = { roles: ['admin'], permissions: [] }) {
+  const app = express();
+  app.use(express.json());
+  app.locals.kafka = { publish: (t: string, p: string) => published.push({ t, p }) };
+  app.use((req, _res, next) => {
+    (req as any).user = user;
+    next();
+  });
+  mountRoleRoutes(app);
+  return app;
+}
+
+test('create role', async () => {
+  const app = makeApp();
+  const res = await request(app).post('/api/roles').send({ name: 'test', permissions: [] });
+  expect(res.status).toBe(200);
+  expect(roles.length).toBe(1);
+  expect(published.length).toBe(1);
+});
+
+test('list roles', async () => {
+  roles.push({ id: 'r1', name: 't1', permissions: [], deleted_at: null, created_at: new Date('2025-01-01T00:00:00Z') });
+  const app = makeApp({ roles: [], permissions: ['iam:roles:read'] });
+  const res = await request(app).get('/api/roles');
+  expect(res.status).toBe(200);
+  expect(res.body.data.items.length).toBe(1);
+});
+
+test('delete role', async () => {
+  roles.push({ id: 'r1', name: 't1', permissions: [], deleted_at: null, created_at: new Date('2025-01-01T00:00:00Z') });
+  const app = makeApp();
+  const res = await request(app).delete('/api/roles/r1');
+  expect(res.status).toBe(204);
+  expect(roles[0].deleted_at).not.toBeNull();
+});

--- a/iam-service/tests/rules.test.ts
+++ b/iam-service/tests/rules.test.ts
@@ -1,0 +1,74 @@
+import request from 'supertest';
+import express from 'express';
+
+let mountRuleRoutes: any;
+const rules: any[] = [];
+const published: any[] = [];
+
+jest.mock('@prisma/client', () => {
+  return {
+    PrismaClient: jest.fn().mockImplementation(() => ({
+      abacRule: {
+        create: jest.fn(({ data }: any) => {
+          const r = { id: `a${rules.length + 1}`, created_at: new Date('2025-01-01T00:00:00Z'), deleted_at: null, ...data };
+          rules.push(r);
+          return Promise.resolve(r);
+        }),
+        update: jest.fn(({ where: { id }, data }: any) => {
+          const r = rules.find((x) => x.id === id)!;
+          Object.assign(r, data);
+          return Promise.resolve(r);
+        }),
+        findMany: jest.fn(({ where }: any) => {
+          let list = rules.filter((r) => r.deleted_at === null);
+          if (where?.name?.contains) list = list.filter((r) => r.name.includes(where.name.contains));
+          if (where?.id?.gt) list = list.filter((r) => r.id > where.id.gt);
+          return Promise.resolve(list);
+        }),
+      },
+    })),
+  };
+});
+
+jest.mock('json-logic-js', () => ({ apply: jest.fn(() => true) }), { virtual: true });
+
+beforeEach(async () => {
+  jest.resetModules();
+  rules.length = 0;
+  published.length = 0;
+  ({ mountRuleRoutes } = await import('../src/routes/rules'));
+});
+
+function makeApp(user: any = { roles: ['admin'], permissions: [] }) {
+  const app = express();
+  app.use(express.json());
+  app.locals.kafka = { publish: (t: string, p: string) => published.push({ t, p }) };
+  app.use((req, _res, next) => { (req as any).user = user; next(); });
+  mountRuleRoutes(app);
+  return app;
+}
+
+test('create rule', async () => {
+  const app = makeApp();
+  const res = await request(app).post('/api/rules').send({ name: 'r', target: 't', json_logic: {} });
+  expect(res.status).toBe(200);
+  expect(rules.length).toBe(1);
+  expect(published.length).toBe(1);
+});
+
+test('invalid logic', async () => {
+  const app = makeApp();
+  // mock apply to throw
+  const logic = require('json-logic-js');
+  logic.apply.mockImplementation(() => { throw new Error('bad'); });
+  const res = await request(app).post('/api/rules').send({ name: 'r', target: 't', json_logic: {} });
+  expect(res.status).toBe(400);
+});
+
+test('list rules requires read perm', async () => {
+  rules.push({ id: 'a1', name: 'r', target: 't', json_logic: {}, deleted_at: null, created_at: new Date('2025-01-01T00:00:00Z') });
+  const app = makeApp({ roles: [], permissions: ['iam:rules:read'] });
+  const res = await request(app).get('/api/rules');
+  expect(res.status).toBe(200);
+  expect(res.body.data.items.length).toBe(1);
+});


### PR DESCRIPTION
## Summary
- add roles routes with CRUD logic and Kafka publish
- add rules routes with JSON logic validation
- unit tests for new roles and rules routes

