### PR TITLE
Add Prometheus metrics and JSON logging

### DIFF
--- a/ai_service/settings.py
+++ b/ai_service/settings.py
@@ -28,6 +28,7 @@ class Settings(BaseSettings):
     class Config:
         env_file = ".env"
         case_sensitive = False
+        extra = "ignore"
 
     def __repr__(self) -> str:  # pragma: no cover - simple utility
         data = self.model_dump()

--- a/iam-service/app/logging.py
+++ b/iam-service/app/logging.py
@@ -1,0 +1,15 @@
+import structlog
+
+
+structlog.configure(
+    processors=[
+        structlog.processors.TimeStamper(fmt="iso", key="timestamp"),
+        structlog.processors.add_log_level,
+        structlog.processors.JSONRenderer(),
+    ]
+)
+
+
+def get_logger() -> structlog.BoundLogger:
+    """Return a service-bound structlog logger."""
+    return structlog.get_logger().bind(service="iam-service")

--- a/iam-service/app/main.py
+++ b/iam-service/app/main.py
@@ -1,8 +1,19 @@
 from fastapi import FastAPI
+
 from .config import settings
+from .logging import get_logger
+from .metrics import init_metrics
+
+logger = get_logger()
 
 app = FastAPI()
+init_metrics(app)
 
 @app.get("/healthz")
 def healthz():
     return {"status": "ok"}
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    logger.info("service_started")

--- a/iam-service/app/metrics.py
+++ b/iam-service/app/metrics.py
@@ -1,0 +1,16 @@
+from fastapi import FastAPI, Response
+from prometheus_client import Counter, generate_latest, CONTENT_TYPE_LATEST
+
+# Module-level Prometheus counters
+login_total = Counter("login_total", "Total user login attempts")
+mfa_challenge_total = Counter("mfa_challenge_total", "Total MFA challenges issued")
+token_revoked_total = Counter("token_revoked_total", "Total revoked tokens")
+
+
+def init_metrics(app: FastAPI) -> None:
+    """Mount /metrics endpoint on the given FastAPI app."""
+
+    @app.get("/metrics", include_in_schema=False)
+    async def metrics() -> Response:  # pragma: no cover - trivial
+        data = generate_latest()
+        return Response(content=data, media_type=CONTENT_TYPE_LATEST)


### PR DESCRIPTION
## Summary
- expose `GET /metrics` for IAM service
- add structlog JSON logging helper
- initialize metrics and logging in FastAPI app
- ignore extra variables in ai_service settings
