### PR TITLE
Fix Go version in token revoker workflow

### DIFF
--- a/.github/workflows/token-revoker.yml
+++ b/.github/workflows/token-revoker.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'   # ≥ 1.23 to satisfy go.mod
+          go-version: '1.23'   # ≥ 1.23 to satisfy go.mod
           check-latest: true
       - name: Install staticcheck
         run: go install honnef.co/go/tools/cmd/staticcheck@latest


### PR DESCRIPTION
## Summary
- update Go setup in `token-revoker.yml` to use Go 1.23

