### PR TITLE
Fix lint errors by removing unused imports

### DIFF
--- a/ai_service/app/scoring_engine.py
+++ b/ai_service/app/scoring_engine.py
@@ -6,7 +6,7 @@ import time
 from collections import defaultdict, deque
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Deque, Dict, List
+from typing import Deque, Dict
 
 import joblib
 import numpy as np

--- a/ai_service/kafka_orchestrator.py
+++ b/ai_service/kafka_orchestrator.py
@@ -1,9 +1,8 @@
 import asyncio
 import json
 import logging
-import os
 import signal
-from typing import Dict, Any, Optional, Tuple
+from typing import Any, Tuple
 
 from aiokafka import AIOKafkaConsumer, AIOKafkaProducer, TopicPartition, OffsetAndMetadata
 from aiokafka.errors import KafkaError


### PR DESCRIPTION
## Summary
- run `ruff` auto-fix to remove unused imports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a230e5834832cbcf0c2969f2125ea