### PR TITLE
Update Go version in workflow

### DIFF
--- a/.github/workflows/token-revoker.yml
+++ b/.github/workflows/token-revoker.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'   # ≥ 1.23 to satisfy go.mod
+          go-version: '1.24'   # ≥ 1.24 to satisfy go.mod
           check-latest: true
       - name: Install staticcheck
         run: go install honnef.co/go/tools/cmd/staticcheck@latest


### PR DESCRIPTION
## Summary
- bump Go version in `token-revoker` GitHub Actions workflow to 1.24

## Testing
- `make lint` *(fails: staticcheck not installed)*
- `make test`
- `pnpm install`
- `pnpm run lint:fix` *(fails: no matching files)*

------
https://chatgpt.com/codex/tasks/task_e_686a6e41bac4832c93c96d834b59bd0d