### PR TITLE
Add ledger-service skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__
 
 models/
 iam-service/coverage
+ledger-service/coverage
+ledger-service/dist

--- a/ledger-service/.env.example
+++ b/ledger-service/.env.example
@@ -1,0 +1,7 @@
+FABRIC_CONNECTION_PROFILE=./fabric/connection.json
+FABRIC_WALLET_PATH=./wallet
+FABRIC_IDENTITY=appUser
+CHANNEL_NAME=trustvault
+CONTRACT_NAME=ledger
+PORT=8085
+LOG_LEVEL=info

--- a/ledger-service/.eslintrc.cjs
+++ b/ledger-service/.eslintrc.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  extends: ['../.eslintrc.cjs', 'plugin:@typescript-eslint/recommended'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: { sourceType: 'module' }
+}

--- a/ledger-service/Dockerfile
+++ b/ledger-service/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json pnpm-lock.yaml tsconfig.json ./
+RUN corepack enable && pnpm install --prod --frozen-lockfile
+COPY src ./src
+ENV NODE_ENV=production
+EXPOSE 8085
+HEALTHCHECK --interval=30s --timeout=5s CMD wget -qO- http://localhost:${PORT}/health || exit 1
+CMD ["node", "--loader", "ts-node/esm", "src/index.ts"]

--- a/ledger-service/README.md
+++ b/ledger-service/README.md
@@ -1,0 +1,23 @@
+# Ledger Service
+
+This package logs SOAR alerts and actions to Hyperledger Fabric and exposes integrity APIs.
+
+## Development
+
+```bash
+pnpm install
+pnpm --filter ledger-service dev
+```
+
+## Production
+
+```bash
+pnpm --filter ledger-service build
+pnpm --filter ledger-service start
+```
+
+To run with Docker:
+
+```bash
+docker compose -f ledger-service/docker-compose.override.yml up --build
+```

--- a/ledger-service/docker-compose.override.yml
+++ b/ledger-service/docker-compose.override.yml
@@ -1,0 +1,18 @@
+version: '3.9'
+services:
+  fabric-devnet:
+    image: hyperledger/fabric-peer:2.5
+    command: bash -c "sleep infinity"
+  ledger-service:
+    build: .
+    env_file: .env.example
+    ports:
+      - "8085:8085"
+    depends_on:
+      - fabric-devnet
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8085/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s

--- a/ledger-service/jest.config.cjs
+++ b/ledger-service/jest.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests'],
+  coveragePathIgnorePatterns: ['<rootDir>/src/client']
+}

--- a/ledger-service/package.json
+++ b/ledger-service/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "ledger-service",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "type": "module",
+  "scripts": {
+    "dev": "ts-node-dev src/index.ts",
+    "build": "tsc -p .",
+    "start": "node dist/index.js",
+    "lint": "eslint \"src/**\"",
+    "test": "jest --coverage"
+  },
+  "dependencies": {
+    "@hyperledger/fabric-gateway": "1.3.0",
+    "csv-stringify": "6.3.0",
+    "dotenv-flow": "4.1.0",
+    "express": "4.19.2",
+    "winston": "3.10.0",
+    "pino-pretty": "10.3.0"
+  },
+  "devDependencies": {
+    "@types/express": "4.17.17",
+    "@types/jest": "29.5.5",
+    "@types/node": "20.8.10",
+    "@types/supertest": "2.0.12",
+    "supertest": "6.3.3",
+    "eslint": "8.56.0",
+    "jest": "29.7.0",
+    "ts-jest": "29.1.1",
+    "ts-node-dev": "2.0.0",
+    "typescript": "5.4.5",
+    "testcontainers": "9.3.0"
+  }
+}

--- a/ledger-service/src/client/index.ts
+++ b/ledger-service/src/client/index.ts
@@ -1,0 +1,26 @@
+/* istanbul ignore file */
+import type { Contract } from '@hyperledger/fabric-gateway'
+import logger from '../logger'
+import { SoarActionEvent } from '../models/event'
+
+class FabricClient {
+  // In a future phase this will connect to Fabric Gateway
+  private contract: Contract | undefined
+
+  async logEvent(event: SoarActionEvent): Promise<void> {
+    logger.info('logEvent', { event })
+    // placeholder for chaincode invoke
+  }
+
+  async verify(runId: string): Promise<boolean> {
+    logger.info('verify', { runId })
+    return true
+  }
+
+  async getEvents(): Promise<SoarActionEvent[]> {
+    logger.info('getEvents')
+    return []
+  }
+}
+
+export default new FabricClient()

--- a/ledger-service/src/env.ts
+++ b/ledger-service/src/env.ts
@@ -1,0 +1,24 @@
+import { config } from 'dotenv-flow'
+config()
+
+export interface Env {
+  FABRIC_CONNECTION_PROFILE: string
+  FABRIC_WALLET_PATH: string
+  FABRIC_IDENTITY: string
+  CHANNEL_NAME: string
+  CONTRACT_NAME: string
+  PORT: number
+  LOG_LEVEL: string
+}
+
+const env: Env = {
+  FABRIC_CONNECTION_PROFILE: process.env.FABRIC_CONNECTION_PROFILE || './fabric/connection.json',
+  FABRIC_WALLET_PATH: process.env.FABRIC_WALLET_PATH || './wallet',
+  FABRIC_IDENTITY: process.env.FABRIC_IDENTITY || 'appUser',
+  CHANNEL_NAME: process.env.CHANNEL_NAME || 'trustvault',
+  CONTRACT_NAME: process.env.CONTRACT_NAME || 'ledger',
+  PORT: Number(process.env.PORT) || 8085,
+  LOG_LEVEL: process.env.LOG_LEVEL || 'info'
+}
+
+export default env

--- a/ledger-service/src/index.ts
+++ b/ledger-service/src/index.ts
@@ -1,0 +1,51 @@
+import express from 'express'
+import { stringify } from 'csv-stringify'
+import env from './env'
+import logger from './logger'
+import client from './client'
+import { SoarActionEvent } from './models/event'
+
+export const app = express()
+app.use(express.json())
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok', service: 'ledger-service' })
+})
+
+app.post('/log-event', async (req, res) => {
+  const event = req.body as SoarActionEvent
+  await client.logEvent(event)
+  res.status(201).json({ status: 'logged' })
+})
+
+app.get('/verify/:runId', async (req, res) => {
+  const verified = await client.verify(req.params.runId)
+  res.json({ runId: req.params.runId, verified })
+})
+
+app.get('/export/csv', async (_req, res) => {
+  const events = await client.getEvents()
+  res.setHeader('Content-Type', 'text/csv')
+  const stringifier = stringify({ header: true })
+  stringifier.pipe(res)
+  events.forEach(e => stringifier.write(e))
+  stringifier.end()
+})
+
+/* istanbul ignore next */
+export async function startServer() {
+  const server = app.listen(env.PORT, () => {
+    logger.info(`ledger-service listening on ${env.PORT}`)
+  })
+  const shutdown = () => server.close(() => process.exit(0))
+  process.on('SIGINT', shutdown)
+  process.on('SIGTERM', shutdown)
+  return server
+}
+
+/* istanbul ignore next */
+if (require.main === module) {
+  startServer()
+}
+
+export default app

--- a/ledger-service/src/logger.ts
+++ b/ledger-service/src/logger.ts
@@ -1,0 +1,11 @@
+import winston from 'winston'
+import env from './env'
+
+const logger = winston.createLogger({
+  level: env.LOG_LEVEL,
+  format: winston.format.json(),
+  defaultMeta: { service: 'ledger-service' },
+  transports: [new winston.transports.Console()]
+})
+
+export default logger

--- a/ledger-service/tests/e2e/ledger.e2e.ts
+++ b/ledger-service/tests/e2e/ledger.e2e.ts
@@ -1,0 +1,10 @@
+import request from 'supertest'
+import app from '../../src'
+
+describe('ledger service', () => {
+  it('health', async () => {
+    const res = await request(app).get('/health')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ status: 'ok', service: 'ledger-service' })
+  })
+})

--- a/ledger-service/tests/unit/app.test.ts
+++ b/ledger-service/tests/unit/app.test.ts
@@ -1,0 +1,35 @@
+import request from 'supertest'
+import app from '../../src'
+import client from '../../src/client'
+
+jest.mock('../../src/client')
+
+describe('routes', () => {
+  it('logs event', async () => {
+    const mock = client as jest.Mocked<typeof client>
+    mock.logEvent.mockResolvedValueOnce()
+    const res = await request(app)
+      .post('/log-event')
+      .send({ runId: '1', action: 'test', message: 'ok', timestamp: 'now' })
+    expect(res.status).toBe(201)
+    expect(mock.logEvent).toHaveBeenCalled()
+  })
+
+  it('verifies run', async () => {
+    const mock = client as jest.Mocked<typeof client>
+    mock.verify.mockResolvedValueOnce(true)
+    const res = await request(app).get('/verify/1')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ runId: '1', verified: true })
+    expect(mock.verify).toHaveBeenCalledWith('1')
+  })
+
+  it('exports csv', async () => {
+    const mock = client as jest.Mocked<typeof client>
+    mock.getEvents.mockResolvedValueOnce([{ runId: '1', action: 'a', message: 'm', timestamp: 't' }])
+    const res = await request(app).get('/export/csv')
+    expect(res.status).toBe(200)
+    expect(res.text).toContain('runId')
+    expect(mock.getEvents).toHaveBeenCalled()
+  })
+})

--- a/ledger-service/tests/unit/logger.test.ts
+++ b/ledger-service/tests/unit/logger.test.ts
@@ -1,0 +1,9 @@
+import logger from '../../src/logger'
+
+describe('logger', () => {
+  it('should have service default meta', () => {
+    // @ts-ignore access private property
+    const meta = (logger as any).defaultMeta
+    expect(meta.service).toBe('ledger-service')
+  })
+})

--- a/ledger-service/tsconfig.json
+++ b/ledger-service/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src", "strict": true },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - soar-service
+  - ledger-service


### PR DESCRIPTION
## Summary
- bootstrap `ledger-service` package with Express APIs
- add Dockerfile and docker compose setup
- configure lint, tests and workspace
- create basic Winston logger and env loader
