### PR TITLE
Add Swagger docs to api-gateway

### DIFF
--- a/api-gateway/.gitignore
+++ b/api-gateway/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+coverage
+dist
+*.log

--- a/api-gateway/README.md
+++ b/api-gateway/README.md
@@ -1,6 +1,7 @@
 # API Gateway
 
 Simple Express API Gateway with a health check endpoint.
+Swagger UI is served at `/docs` and the raw JSON at `/docs-json`.
 
 ## Development
 

--- a/api-gateway/package.json
+++ b/api-gateway/package.json
@@ -12,13 +12,18 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@apidevtools/swagger-parser": "^12.0.0",
     "dotenv": "16.6.1",
-    "express": "4.19.2"
+    "express": "4.19.2",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "@types/express": "4.17.17",
     "@types/node": "20.8.10",
     "@types/supertest": "2.0.12",
+    "@types/swagger-jsdoc": "^6.0.4",
+    "@types/swagger-ui-express": "^4.1.8",
     "@typescript-eslint/eslint-plugin": "6.19.1",
     "@typescript-eslint/parser": "6.19.1",
     "@vitest/coverage-v8": "^1.6.1",

--- a/api-gateway/src/index.ts
+++ b/api-gateway/src/index.ts
@@ -1,10 +1,16 @@
 import express from 'express'
 import dotenv from 'dotenv'
+import swaggerUi from 'swagger-ui-express'
+import openapiSpec from './lib/openapi'
+import exampleRoutes from './routes/example'
 
 dotenv.config()
 
 export function createApp() {
   const app = express()
+  app.use(exampleRoutes)
+  app.get('/docs-json', (_req, res) => res.json(openapiSpec))
+  app.use('/docs', swaggerUi.serve, swaggerUi.setup(openapiSpec))
   app.get('/healthz', (_req, res) => {
     res.json({ status: 'ok' })
   })

--- a/api-gateway/src/lib/openapi.ts
+++ b/api-gateway/src/lib/openapi.ts
@@ -1,0 +1,16 @@
+import swaggerJsdoc from 'swagger-jsdoc'
+
+const options = {
+  definition: {
+    openapi: '3.1.0',
+    info: {
+      title: process.env.NPM_PACKAGE_NAME ?? 'TrustVault API Gateway',
+      version: process.env.NPM_PACKAGE_VERSION ?? '0.0.0',
+    },
+  },
+  apis: ['src/routes/**/*.ts'],
+}
+
+const openapiSpec = swaggerJsdoc(options)
+
+export default openapiSpec

--- a/api-gateway/src/routes/example.ts
+++ b/api-gateway/src/routes/example.ts
@@ -1,0 +1,26 @@
+import { Router } from 'express'
+
+const router = Router()
+
+/**
+ * @openapi
+ * /hello:
+ *   get:
+ *     summary: Example hello endpoint
+ *     responses:
+ *       200:
+ *         description: Returns greeting
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: hello
+ */
+router.get('/hello', (_req, res) => {
+  res.json({ message: 'hello' })
+})
+
+export default router

--- a/api-gateway/tests/openapi.spec.ts
+++ b/api-gateway/tests/openapi.spec.ts
@@ -1,0 +1,13 @@
+import request from 'supertest'
+import { createApp } from '../src/index'
+import { describe, it, expect } from 'vitest'
+import SwaggerParser from '@apidevtools/swagger-parser'
+
+describe('swagger spec', () => {
+  it('swagger spec is valid', async () => {
+    const app = createApp()
+    const spec = (await request(app).get('/docs-json')).body
+    await SwaggerParser.validate(spec)
+    expect(spec.openapi).toBe('3.1.0')
+  })
+})


### PR DESCRIPTION
## Summary
- generate OpenAPI 3.1 spec via swagger-jsdoc
- serve Swagger UI and raw JSON
- add example route with `@openapi` annotations
- validate spec in new vitest test
- document docs endpoints

