### PR TITLE
Add OpenAI usage logging middleware

### DIFF
--- a/api-gateway/package.json
+++ b/api-gateway/package.json
@@ -22,7 +22,8 @@
     "socket.io-client": "^4.8.1",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
-    "zod": "3.24.4"
+    "zod": "3.24.4",
+    "pg": "^8.11.5"
   },
   "devDependencies": {
     "@types/express": "4.17.17",
@@ -41,6 +42,7 @@
     "supertest": "6.3.3",
     "ts-node": "10.9.1",
     "typescript": "5.4.5",
-    "vitest": "^1.6.1"
+    "vitest": "^1.6.1",
+    "pg-mem": "^2.1.3"
   }
 }

--- a/api-gateway/src/index.ts
+++ b/api-gateway/src/index.ts
@@ -2,6 +2,8 @@ import express from 'express'
 import dotenv from 'dotenv'
 import swaggerUi from 'swagger-ui-express'
 import openapiSpec from './lib/openapi'
+import pool from './lib/db'
+import openaiUsage from './middleware/openaiUsage'
 import exampleRoutes from './routes/example'
 import alertsRoutes from './routes/alerts'
 import sessionsRoutes from './routes/sessions'
@@ -13,6 +15,7 @@ dotenv.config()
 
 export function createApp() {
   const app = express()
+  app.use(openaiUsage(pool))
   app.use(exampleRoutes)
   app.use(alertsRoutes)
   app.use(sessionsRoutes)

--- a/api-gateway/src/lib/db.ts
+++ b/api-gateway/src/lib/db.ts
@@ -1,0 +1,8 @@
+import { Pool } from 'pg'
+import dotenv from 'dotenv'
+
+dotenv.config()
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL })
+
+export default pool

--- a/api-gateway/src/middleware/openaiUsage.ts
+++ b/api-gateway/src/middleware/openaiUsage.ts
@@ -1,0 +1,31 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express'
+import { z } from 'zod'
+import { Pool } from 'pg'
+
+const usageSchema = z.object({
+  model: z.string(),
+  prompt_tokens: z.number(),
+  completion_tokens: z.number(),
+  cost: z.number()
+})
+
+export default function openaiUsage(pool: Pool): RequestHandler {
+  return function (req: Request, _res: Response, next: NextFunction) {
+    const header = req.header('x-openai-usage')
+    if (!header) return next()
+    try {
+      const usage = usageSchema.parse(JSON.parse(header))
+      void pool
+        .query(
+          'INSERT INTO openai_usage(model, prompt_tokens, completion_tokens, cost) VALUES ($1,$2,$3,$4)',
+          [usage.model, usage.prompt_tokens, usage.completion_tokens, usage.cost]
+        )
+        .catch((err) => {
+          console.error('openai_usage insert failed', err)
+        })
+    } catch {
+      // ignore malformed header
+    }
+    next()
+  }
+}

--- a/api-gateway/tests/openaiUsage.spec.ts
+++ b/api-gateway/tests/openaiUsage.spec.ts
@@ -1,0 +1,46 @@
+import request from 'supertest'
+import express from 'express'
+import { newDb } from 'pg-mem'
+import openaiUsage from '../src/middleware/openaiUsage'
+import { describe, it, expect } from 'vitest'
+
+function setup() {
+  const db = newDb()
+  db.public.none(`CREATE TABLE openai_usage(
+    model text not null,
+    prompt_tokens integer not null,
+    completion_tokens integer not null,
+    cost double precision not null
+  )`)
+  const { Pool } = db.adapters.createPg()
+  const pool = new Pool()
+  const app = express()
+  app.use(openaiUsage(pool))
+  app.get('/test', (_req, res) => res.json({ ok: true }))
+  return { app, pool }
+}
+
+describe('openai usage middleware', () => {
+  it('records header data', async () => {
+    const { app, pool } = setup()
+    const header = {
+      model: 'gpt-4o',
+      prompt_tokens: 1,
+      completion_tokens: 2,
+      cost: 0.1
+    }
+    await request(app)
+      .get('/test')
+      .set('x-openai-usage', JSON.stringify(header))
+    const rows = await pool.query('SELECT * FROM openai_usage')
+    expect(rows.rowCount).toBe(1)
+    expect(rows.rows[0].model).toBe('gpt-4o')
+  })
+
+  it('ignores missing header', async () => {
+    const { app, pool } = setup()
+    await request(app).get('/test')
+    const rows = await pool.query('SELECT * FROM openai_usage')
+    expect(rows.rowCount).toBe(0)
+  })
+})

--- a/iam-service/prisma/migrations/20250708_add_openai_usage/migration.sql
+++ b/iam-service/prisma/migrations/20250708_add_openai_usage/migration.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS openai_usage (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  model TEXT NOT NULL,
+  prompt_tokens INTEGER NOT NULL,
+  completion_tokens INTEGER NOT NULL,
+  cost DOUBLE PRECISION NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/iam-service/prisma/schema.prisma
+++ b/iam-service/prisma/schema.prisma
@@ -1,0 +1,22 @@
+// Prisma schema for IAM service
+// Extended with OpenAIUsage model
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model OpenAIUsage {
+  id               String   @id @default(uuid()) @db.Uuid
+  model            String
+  promptTokens     Int      @map("prompt_tokens")
+  completionTokens Int      @map("completion_tokens")
+  cost             Float
+  createdAt        DateTime @default(now()) @map("created_at")
+
+  @@map("openai_usage")
+}


### PR DESCRIPTION
## Summary
- add middleware to log `x-openai-usage` header
- expose pg pool helper
- mount middleware in express app
- extend IAM service prisma schema for `openai_usage`
- add SQL migration
- unit tests with `pg-mem`
