### PR TITLE
Add docker compose override for API Gateway

### DIFF
--- a/api-gateway/README.md
+++ b/api-gateway/README.md
@@ -10,4 +10,17 @@ npm install
 npm run dev
 ```
 
-Visit `http://localhost:8000/healthz`.
+Visit `http://localhost:8080/healthz`.
+
+## Production
+
+```bash
+npm run build
+npm start
+```
+
+To run with Docker:
+
+```bash
+docker compose -f api-gateway/docker-compose.override.yml up --build
+```

--- a/api-gateway/docker-compose.override.yml
+++ b/api-gateway/docker-compose.override.yml
@@ -1,0 +1,26 @@
+version: '3.9'
+services:
+  api-gateway:
+    build: .
+    environment:
+      - PORT=8080
+      - JWT_SECRET=${JWT_SECRET}
+      - ALERTS_URL=http://alerts:8081
+      - IAM_URL=http://iam:8000
+      - SOAR_URL=http://soar-service:8083
+      - LEDGER_URL=http://ledger-service:8084
+      - SOCKET_CORS_ORIGINS=https://app.trustvault.io,https://console.trustvault.io
+      - METRICS_PORT=8080
+    ports:
+      - "8080:8080"
+    depends_on:
+      - alerts
+      - iam
+      - soar-service
+      - ledger-service
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s


### PR DESCRIPTION
## Summary
- add `docker-compose.override.yml` for the API Gateway service
- document production and Docker usage in API Gateway README

## Testing
- `pnpm --filter api-gateway test`

------
https://chatgpt.com/codex/tasks/task_e_686adac18338832ca9ef22b5d5f436fa