### PR TITLE
Add LiveUpdates websocket cache component

### DIFF
--- a/ui-dashboard/components/LiveUpdates.tsx
+++ b/ui-dashboard/components/LiveUpdates.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from 'react';
+import { useQueryClient } from 'react-query';
+import throttle from 'lodash/throttle';
+import useWebSocket from '@/ui-dashboard/hooks/useWebSocket';
+
+export default function LiveUpdates(): null {
+  const queryClient = useQueryClient();
+  const handlerRef = useRef<(event: string, payload: any) => void>();
+
+  useEffect(() => {
+    const throttled = throttle((event: string, payload: any) => {
+      queryClient.invalidateQueries('alerts');
+      if (event === 'alertCreated' && payload?.severity === 'high') {
+        queryClient.invalidateQueries('metrics');
+      }
+    }, 1000);
+
+    handlerRef.current = throttled;
+    return () => {
+      throttled.cancel();
+    };
+  }, [queryClient]);
+
+  useWebSocket('/ws/alerts', ['alertCreated', 'alertUpdated'], (event, payload) => {
+    handlerRef.current?.(event, payload);
+  });
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add new `LiveUpdates` component to push websocket alerts into React Query cache

## Testing
- `pnpm --filter api-gateway test`
- `pnpm --filter ledger-service test`
- `pnpm --filter soar-service test`
- `pnpm --filter iam-service test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686afb8ad4c0832c876fd494eb41d45c