### PR TITLE
Add Cypress test for dashboard alerts

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,0 +1,8 @@
+const { defineConfig } = require('cypress');
+
+module.exports = defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:5173',
+    specPattern: 'cypress/integration/**/*.js',
+  },
+});

--- a/cypress/integration/dashboard.spec.js
+++ b/cypress/integration/dashboard.spec.js
@@ -1,0 +1,32 @@
+/// <reference types="cypress" />
+
+const alertPayload = {
+  id: 'alert-1',
+  title: 'High-severity test alert',
+  severity: 'high',
+  timestamp: new Date().toISOString(),
+};
+
+describe('Dashboard', () => {
+  it('renders high severity alert and updates CPU gauge', () => {
+    cy.intercept('/api/metrics', {
+      cpuUsage: 42,
+      memUsage: 58,
+      reqRate: 5,
+    }).as('getMetrics');
+
+    cy.visit('/dashboard');
+
+    cy.window().then((win) => {
+      if (win.socket) {
+        win.socket.emit('alertCreated', alertPayload);
+      }
+    });
+
+    cy.contains('High-severity test alert').should('be.visible');
+
+    cy.wait('@getMetrics');
+
+    cy.contains('42').should('exist');
+  });
+});


### PR DESCRIPTION
## Summary
- add Cypress configuration
- create dashboard E2E test covering alerts and metrics

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: asyncpg)*
- `pnpm --filter api-gateway test` *(fails: vitest not found)*
- `npx cypress run --spec cypress/integration/dashboard.spec.js` *(fails: needs package cypress)*

------
https://chatgpt.com/codex/tasks/task_e_686afce50ae0832cacd659c0e629c54a