### PR TITLE
Add AWS monitoring Terraform configuration

### DIFF
--- a/terraform/monitoring/cloudwatch.tf
+++ b/terraform/monitoring/cloudwatch.tf
@@ -1,0 +1,27 @@
+resource "aws_cloudwatch_log_group" "service_logs" {
+  for_each          = toset(var.service_names)
+  name              = "/trustvault/${each.value}"
+  retention_in_days = 30
+
+  tags = local.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "cpu_high" {
+  for_each            = toset(var.service_names)
+  alarm_name          = "${each.value}-cpu-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = 60
+  statistic           = "Average"
+  threshold           = 80
+
+  dimensions = {
+    AutoScalingGroupName = each.value
+  }
+
+  treat_missing_data = "missing"
+
+  tags = local.tags
+}

--- a/terraform/monitoring/iam.tf
+++ b/terraform/monitoring/iam.tf
@@ -1,0 +1,53 @@
+# IAM role for Prometheus node group
+
+data "aws_iam_policy_document" "prometheus_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "prometheus_node_role" {
+  name               = "prometheus-node-role-${var.environment}"
+  assume_role_policy = data.aws_iam_policy_document.prometheus_assume.json
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "eks_worker" {
+  role       = aws_iam_role.prometheus_node_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "ecr_read" {
+  role       = aws_iam_role.prometheus_node_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+resource "aws_iam_policy" "prometheus_scrape" {
+  name   = "prometheus-scrape-${var.environment}"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = [
+          "cloudwatch:ListMetrics",
+          "cloudwatch:GetMetricData",
+          "cloudwatch:GetMetricStatistics",
+          "logs:DescribeLogStreams",
+          "logs:GetLogEvents"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "scrape_attach" {
+  role       = aws_iam_role.prometheus_node_role.name
+  policy_arn = aws_iam_policy.prometheus_scrape.arn
+}

--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_version = ">= 1.5"
+
+  backend "s3" {
+    bucket = "trustvault-terraform-state"
+    key    = "monitoring/terraform.tfstate"
+    region = var.region
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+data "terraform_remote_state" "network" {
+  backend = "s3"
+  config = {
+    bucket = "trustvault-terraform-state"
+    key    = "network/terraform.tfstate"
+    region = var.region
+  }
+}
+
+resource "aws_s3_bucket" "grafana_dashboards" {
+  bucket = "trustvault-grafana-dashboards-${var.environment}"
+
+  versioning {
+    enabled = true
+  }
+
+  tags = local.tags
+}

--- a/terraform/monitoring/outputs.tf
+++ b/terraform/monitoring/outputs.tf
@@ -1,0 +1,7 @@
+output "grafana_bucket" {
+  value = aws_s3_bucket.grafana_dashboards.id
+}
+
+output "prometheus_node_role_arn" {
+  value = aws_iam_role.prometheus_node_role.arn
+}

--- a/terraform/monitoring/prometheus_eks.tf
+++ b/terraform/monitoring/prometheus_eks.tf
@@ -1,0 +1,16 @@
+resource "aws_eks_node_group" "prometheus" {
+  cluster_name    = data.terraform_remote_state.network.outputs.eks_cluster_name
+  node_group_name = "prometheus"
+  node_role_arn   = aws_iam_role.prometheus_node_role.arn
+  subnet_ids      = data.terraform_remote_state.network.outputs.private_subnet_ids
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+
+  instance_types = ["t3.micro"]
+
+  tags = local.tags
+}

--- a/terraform/monitoring/variables.tf
+++ b/terraform/monitoring/variables.tf
@@ -1,0 +1,21 @@
+variable "region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "environment" {
+  type    = string
+  default = "dev"
+}
+
+variable "service_names" {
+  type    = list(string)
+  default = ["api", "iam", "soar"]
+}
+
+locals {
+  tags = {
+    Environment = var.environment
+    Project     = "TrustVault"
+  }
+}


### PR DESCRIPTION
## Summary
- add monitoring terraform code
- set up S3 backend and provider
- create IAM roles and policy for Prometheus
- provision Prometheus EKS node group example
- define CloudWatch log groups and alarms
