### PR TITLE
Add Grafana provisioning config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ models/
 iam-service/coverage
 ledger-service/coverage
 ledger-service/dist
+soar-service/coverage

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -106,6 +106,8 @@ services:
     build: ../services/grafana
     ports:
       - "${GRAFANA_PORT}:3000"
+    volumes:
+      - ../scripts/grafana/provisioning:/etc/grafana/provisioning
     depends_on:
       - prometheus
     restart: unless-stopped

--- a/scripts/grafana/provisioning/dashboards.yml
+++ b/scripts/grafana/provisioning/dashboards.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+providers:
+  - name: 'TrustVault'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: ./dashboards

--- a/scripts/grafana/provisioning/dashboards/trustvault-dashboard.json
+++ b/scripts/grafana/provisioning/dashboards/trustvault-dashboard.json
@@ -1,0 +1,63 @@
+{
+  "uid": "trustvault-main",
+  "title": "TrustVault Main",
+  "tags": ["trustvault"],
+  "timezone": "browser",
+  "schemaVersion": 37,
+  "version": 1,
+  "panels": [
+    {
+      "type": "gauge",
+      "title": "CPU Utilization",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum(rate(container_cpu_usage_seconds_total{container!='',pod=~'$service.*'}[5m])) by (pod) * 100",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "max": 100
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNonNull"],
+          "values": false,
+          "fields": "" 
+        }
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0}
+    },
+    {
+      "type": "heatmap",
+      "title": "Memory Usage (24h)",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "container_memory_usage_bytes{container!='',pod=~'$service.*'}",
+          "refId": "B"
+        }
+      ],
+      "options": {
+        "legend": {"show": true}
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+      "timeFrom": "24h"
+    },
+    {
+      "type": "timeseries",
+      "title": "Alert Count",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum(increase(postgres_alerts_total[5m]))",
+          "refId": "C"
+        }
+      ],
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 8}
+    }
+  ]
+}

--- a/scripts/grafana/provisioning/datasources.yml
+++ b/scripts/grafana/provisioning/datasources.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    url: http://prometheus.monitoring.svc.cluster.local:9090
+    access: proxy
+    isDefault: true
+    editable: false


### PR DESCRIPTION
## Summary
- set up Grafana datasources and dashboards provisioning
- mount provisioning directory in docker-compose
- ignore Soar service coverage output
