### PR TITLE
Add FeedbackModal component

### DIFF
--- a/ui-dashboard/components/IncidentCard.tsx
+++ b/ui-dashboard/components/IncidentCard.tsx
@@ -28,9 +28,11 @@ function severityClasses(severity: Incident['severity']): string {
 export default function IncidentCard({
   incident,
   onClick,
+  children,
 }: {
   incident: Incident;
   onClick?: () => void;
+  children?: React.ReactNode;
 }): JSX.Element {
   const title = incident.title || 'Untitled incident';
   let timeText = '—';
@@ -58,6 +60,7 @@ export default function IncidentCard({
         <Clock size={16} className="inline-block mr-1" />
         {timeText}
       </p>
+      {children}
     </Card>
   );
 }

--- a/ui-dashboard/src/components/FeedbackModal/FeedbackModal.tsx
+++ b/ui-dashboard/src/components/FeedbackModal/FeedbackModal.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from 'react';
+import { Modal, Button, Textarea, Toast } from 'shadcn/ui';
+import { useMutation, useQueryClient } from 'react-query';
+import { z } from 'zod';
+
+const feedbackSchema = z.object({
+  reason: z.string().min(1, 'Reason is required'),
+});
+export type FeedbackInput = z.infer<typeof feedbackSchema>;
+
+interface FeedbackModalProps {
+  alertId: string;
+}
+
+export default function FeedbackModal({ alertId }: FeedbackModalProps): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const [reason, setReason] = useState('');
+  const [toastState, setToastState] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async (data: FeedbackInput) => {
+      const res = await fetch('/ai-service/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ alertId, reason: data.reason }),
+      });
+      if (!res.ok) throw new Error('Request failed');
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(['/api/alerts']);
+      setOpen(false);
+      setReason('');
+      setToastState({ type: 'success', message: 'Feedback submitted' });
+    },
+    onError: () => {
+      setToastState({ type: 'error', message: 'Failed to submit feedback' });
+    },
+  });
+
+  const valid = feedbackSchema.safeParse({ reason }).success;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!valid) return;
+    mutation.mutate({ reason });
+  };
+
+  return (
+    <>
+      <Button size="sm" onClick={() => setOpen(true)} aria-haspopup="dialog">
+        Mark False
+      </Button>
+      <Modal open={open} onOpenChange={setOpen} aria-labelledby="feedback-title">
+        <Modal.Content className="space-y-4">
+          <Modal.Title id="feedback-title">Mark False Positive</Modal.Title>
+          <form onSubmit={handleSubmit} className="space-y-2">
+            <label className="flex flex-col gap-1">
+              <span>Reason</span>
+              <Textarea
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                rows={4}
+                className="resize-y"
+              />
+            </label>
+            <div className="flex justify-end gap-2">
+              <Button type="button" variant="ghost" onClick={() => setOpen(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={!valid || mutation.isPending}>
+                {mutation.isPending ? 'Submitting...' : 'Submit'}
+              </Button>
+            </div>
+          </form>
+        </Modal.Content>
+      </Modal>
+      {toastState && (
+        <Toast open variant={toastState.type} onOpenChange={() => setToastState(null)}>
+          {toastState.message}
+        </Toast>
+      )}
+    </>
+  );
+}

--- a/ui-dashboard/src/components/FeedbackModal/feedback.css
+++ b/ui-dashboard/src/components/FeedbackModal/feedback.css
@@ -1,0 +1,7 @@
+/* Styles for FeedbackModal.
+   Provide modal sizing and responsive textarea behaviour. */
+
+.feedback-modal textarea {
+  min-height: 4rem;
+  width: 100%;
+}


### PR DESCRIPTION
## Summary
- add reusable FeedbackModal component
- integrate FeedbackModal usage via children in IncidentCard
- add placeholder CSS for feedback styling

## Testing
- `pnpm lint` *(fails: No files matching src/**/*.{ts,tsx})*

------
https://chatgpt.com/codex/tasks/task_e_686b0ae8ab5c832ca1012cc9879f0b6a