### PR TITLE
Add TrustVault CI/CD workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,88 @@
+name: TrustVault Build and Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: npm ci
+      - name: Install flake8
+        run: pip install flake8
+      - name: Lint JS
+        run: npm run lint
+      - name: Lint Python
+        run: flake8 .
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: npm ci
+      - name: Install pytest
+        run: pip install pytest pytest-cov
+      - name: Run unit tests (JS)
+        run: npm test -- --coverage
+      - name: Run unit tests (Python)
+        run: pytest --maxfail=1 --disable-warnings --cov
+
+  e2e-tests:
+    runs-on: ubuntu-latest
+    needs: unit-tests
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Start app
+        run: npm run dev &
+      - name: Cypress run
+        run: npx cypress run
+
+  build:
+    runs-on: ubuntu-latest
+    needs: e2e-tests
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build frontend
+        run: npm run build
+      - name: Build backend image
+        run: docker build -t trustvault-api ./api
+

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,87 @@
+name: Deploy Dev
+
+on:
+  push:
+    branches: [dev]
+
+jobs:
+  checkout:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+  setup-aws:
+    runs-on: ubuntu-latest
+    needs: checkout
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+  terraform-init-plan:
+    runs-on: ubuntu-latest
+    needs: setup-aws
+    steps:
+      - uses: actions/checkout@v4
+      - name: Terraform Init
+        run: |
+          cd deployment/terraform/dev
+          terraform init -backend-config=${{ secrets.TF_BACKEND_CONFIG }}
+      - name: Terraform Plan
+        run: |
+          cd deployment/terraform/dev
+          terraform plan
+
+  terraform-apply:
+    runs-on: ubuntu-latest
+    needs: terraform-init-plan
+    steps:
+      - uses: actions/checkout@v4
+      - name: Apply Terraform
+        run: |
+          cd deployment/terraform/dev
+          terraform apply -auto-approve
+
+  docker-build-push:
+    runs-on: ubuntu-latest
+    needs: terraform-apply
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build API image
+        run: docker build -t trustvault-api:dev ./api
+      - name: Build UI image
+        run: docker build -t trustvault-ui:dev ./ui
+      - name: Login to ECR
+        run: aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.ECR_REGISTRY }}
+      - name: Push images
+        run: |
+          docker push ${{ secrets.ECR_REGISTRY }}/trustvault-api:dev
+          docker push ${{ secrets.ECR_REGISTRY }}/trustvault-ui:dev
+
+  deploy-to-k8s:
+    runs-on: ubuntu-latest
+    needs: docker-build-push
+    steps:
+      - uses: actions/checkout@v4
+      - name: Helm upgrade
+        run: helm upgrade trustvault chart/ --namespace dev --install --wait --set image.tag=dev
+
+  health-check:
+    runs-on: ubuntu-latest
+    needs: deploy-to-k8s
+    steps:
+      - uses: actions/checkout@v4
+      - name: Wait for rollout
+        run: kubectl rollout status deployment/trustvault -n dev
+      - name: Run probe
+        run: ./scripts/probe.sh dev
+      - name: Rollback on failure
+        if: failure()
+        run: helm rollback trustvault --namespace dev
+

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,103 @@
+name: Deploy Prod
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  checkout:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+  setup-aws:
+    runs-on: ubuntu-latest
+    needs: checkout
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+  terraform-init-plan:
+    runs-on: ubuntu-latest
+    needs: setup-aws
+    steps:
+      - uses: actions/checkout@v4
+      - name: Terraform Init
+        run: |
+          cd deployment/terraform/production
+          terraform init -backend-config=${{ secrets.TF_BACKEND_CONFIG }}
+      - name: Terraform Plan
+        run: |
+          cd deployment/terraform/production
+          terraform plan
+
+  terraform-apply:
+    runs-on: ubuntu-latest
+    needs: terraform-init-plan
+    steps:
+      - uses: actions/checkout@v4
+      - name: Apply Terraform
+        run: |
+          cd deployment/terraform/production
+          terraform apply -auto-approve
+
+  docker-build-push:
+    runs-on: ubuntu-latest
+    needs: terraform-apply
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build API image
+        run: docker build -t trustvault-api:latest ./api
+      - name: Build UI image
+        run: docker build -t trustvault-ui:latest ./ui
+      - name: Login to ECR
+        run: aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.ECR_REGISTRY }}
+      - name: Push images
+        run: |
+          docker push ${{ secrets.ECR_REGISTRY }}/trustvault-api:latest
+          docker push ${{ secrets.ECR_REGISTRY }}/trustvault-ui:latest
+
+  helm-upgrade:
+    runs-on: ubuntu-latest
+    needs: docker-build-push
+    steps:
+      - uses: actions/checkout@v4
+      - name: Helm upgrade
+        run: helm upgrade trustvault chart/ --namespace prod --install --wait --set image.tag=latest
+
+  health-check:
+    runs-on: ubuntu-latest
+    needs: helm-upgrade
+    steps:
+      - uses: actions/checkout@v4
+      - name: Wait for rollout
+        run: kubectl rollout status deployment/trustvault -n prod
+      - name: Run probe
+        run: ./scripts/probe.sh prod
+      - name: Rollback on failure
+        if: failure()
+        run: helm rollback trustvault --namespace prod
+      - name: Slack notify success
+        if: success()
+        uses: slackapi/slack-github-action@v1
+        with:
+          payload: |
+            {"text":"Production deployment succeeded"}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      - name: Slack notify failure
+        if: failure()
+        uses: slackapi/slack-github-action@v1
+        with:
+          payload: |
+            {"text":"Production deployment failed"}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+


### PR DESCRIPTION
## Summary
- add build-and-test workflow running lint, unit and e2e tests
- add dev deployment workflow with Terraform and Helm
- add production deployment workflow with Slack notifications
