### PR TITLE
Add TrustVault SLO/SLA docs

### DIFF
--- a/ops/sla.md
+++ b/ops/sla.md
@@ -1,0 +1,44 @@
+---
+title: "TrustVault SLA"
+sidebar_position: 4
+---
+
+# Service Level Agreement - TrustVault
+
+This document defines the formal service commitments for the TrustVault platform.
+
+## Availability & Latency Targets
+
+- **Availability:** 99.9% monthly availability for the `/alerts` and `/anomaly` endpoints.
+- **Latency:** p99 latency under **200&nbsp;ms** for these endpoints.
+- **Error Rate:** less than **0.5%** failed requests over a rolling 30&nbsp;day window.
+
+## Measurement Methods
+
+Metrics are collected via Prometheus and visualized in Grafana. Key PromQL queries:
+
+```promql
+# p99 latency for /alerts and /anomaly
+histogram_quantile(0.99, sum(rate(api_gateway_latency_ms_bucket{route=~"/(alerts|anomaly)"}[5m])) by (le))
+
+# error rate percentage over 5m windows
+sum(rate(api_gateway_requests_total{route=~"/(alerts|anomaly)",status!~"2.."}[5m]))
+  / sum(rate(api_gateway_requests_total{route=~"/(alerts|anomaly)"}[5m])) * 100
+
+# availability
+sum(rate(api_gateway_requests_total{route=~"/(alerts|anomaly)",status=~"2.."}[5m]))
+  / sum(rate(api_gateway_requests_total{route=~"/(alerts|anomaly)"}[5m]))
+```
+
+## Reporting Cadence
+
+Compliance reports are generated **monthly** and exported as PDF files. Reports include graphs from Grafana and are archived in the internal document portal.
+
+## Escalation Path
+
+Operational issues follow the on-call rotation defined in [Maintenance & On-Call Guide](../docs/MAINTENANCE.md). PagerDuty service: `trustvault-core`.
+
+## Related Dashboards & Alerts
+
+- Grafana dashboard: [TrustVault Main](https://grafana.example.com/d/trustvault-main)
+- Alert policies: `latency-alert` and `error-rate-alert` defined in [`slo.yaml`](./slo.yaml)

--- a/ops/slo.yaml
+++ b/ops/slo.yaml
@@ -1,0 +1,78 @@
+# ---
+# title: "TrustVault SLOs"
+# sidebar_position: 5
+# ---
+
+apiVersion: openslo/v1
+kind: Service
+metadata:
+  name: trustvault
+  displayName: TrustVault API
+spec:
+  owner: platform-team
+  product: trustvault
+  links:
+    - name: Grafana Dashboard
+      url: https://grafana.example.com/d/trustvault-main
+
+---
+apiVersion: openslo/v1
+kind: SLO
+metadata:
+  name: latency-slo
+  displayName: Alerts & Anomaly latency
+spec:
+  service: trustvault
+  description: p99 latency for /alerts and /anomaly endpoints must be < 200ms
+  indicator:
+    thresholdMetric:
+      metricSource:
+        type: Prometheus
+        spec:
+          query: |
+            histogram_quantile(
+              0.99,
+              sum(rate(api_gateway_latency_ms_bucket{route=~"/(alerts|anomaly)"}[5m])) by (le)
+            )
+  objective:
+    op: lt
+    value: 200
+    target: 0.999
+  timeWindow:
+    duration: 30d
+    isRolling: true
+  budgetingMethod: Occurrences
+  alertPolicies:
+    - latency-alert
+
+---
+apiVersion: openslo/v1
+kind: SLO
+metadata:
+  name: error-rate-slo
+  displayName: Alerts & Anomaly error rate
+spec:
+  service: trustvault
+  description: Error rate for /alerts and /anomaly endpoints must stay below 0.5%.
+  indicator:
+    ratioMetric:
+      good:
+        metricSource:
+          type: Prometheus
+          spec:
+            query: |
+              sum(rate(api_gateway_requests_total{route=~"/(alerts|anomaly)",status=~"2.."}[5m]))
+      total:
+        metricSource:
+          type: Prometheus
+          spec:
+            query: |
+              sum(rate(api_gateway_requests_total{route=~"/(alerts|anomaly)"}[5m]))
+  objective:
+    target: 0.995
+  timeWindow:
+    duration: 30d
+    isRolling: true
+  budgetingMethod: Occurrences
+  alertPolicies:
+    - error-rate-alert


### PR DESCRIPTION
## Summary
- document TrustVault service SLOs in OpenSLO format
- add formal SLA including PromQL and escalation path
 