### PR TITLE
Add user guide and SDK examples

### DIFF
--- a/docs/sdk/alerts.ts
+++ b/docs/sdk/alerts.ts
@@ -1,0 +1,26 @@
+/**
+ * Example of interacting with the TrustVault alerts API.
+ *
+ * npm install @trustvault/sdk
+ */
+import { TrustVaultClient } from '@trustvault/sdk'
+
+const client = new TrustVaultClient({
+  baseUrl: 'https://api.trustvault.io',
+  token: process.env.TOKEN ?? '',
+})
+
+interface AlertInput {
+  message: string
+  severity: 'info' | 'warning' | 'critical'
+}
+
+export async function createAlert(input: AlertInput): Promise<void> {
+  const alert = await client.post<{ id: string }>('/api/alerts', input)
+  console.log('Created alert', alert.id)
+}
+
+export async function listAlerts(): Promise<void> {
+  const alerts = await client.get<Array<{ id: string; message: string }>>('/api/alerts')
+  alerts.forEach((a) => console.log(`${a.id}: ${a.message}`))
+}

--- a/docs/sdk/metrics.ts
+++ b/docs/sdk/metrics.ts
@@ -1,0 +1,18 @@
+/**
+ * Example for retrieving metrics.
+ *
+ * npm install @trustvault/sdk
+ */
+import { TrustVaultClient } from '@trustvault/sdk'
+
+const client = new TrustVaultClient({
+  baseUrl: 'https://api.trustvault.io',
+  token: process.env.TOKEN ?? '',
+})
+
+export async function getMetrics(): Promise<void> {
+  const metrics = await client.get<Record<string, number>>('/api/metrics')
+  console.log(metrics)
+}
+
+getMetrics().catch(console.error)

--- a/docs/sdk/stubs.d.ts
+++ b/docs/sdk/stubs.d.ts
@@ -1,0 +1,12 @@
+declare module '@trustvault/sdk' {
+  export interface TrustVaultClientConfig {
+    baseUrl: string
+    token?: string
+  }
+
+  export class TrustVaultClient {
+    constructor(config: TrustVaultClientConfig)
+    get<T>(path: string): Promise<T>
+    post<T>(path: string, body?: unknown): Promise<T>
+  }
+}

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,68 @@
+---
+title: "User Guide"
+sidebar_position: 4
+---
+
+# TrustVault User Walkthrough
+
+Welcome to the TrustVault platform. This guide walks you through the basic UI workflow from logging in to submitting feedback.
+
+## 1. Logging In
+
+1. Navigate to [https://app.trustvault.io](https://app.trustvault.io).
+2. Enter your **email** and **password**.
+3. Click **Login**.
+
+![Login Screen](https://placehold.co/600x400?text=Login)
+
+```mermaid
+flowchart TD
+    A[Open Login Page] --> B{Enter credentials?}
+    B -- yes --> C[Dashboard]
+    B -- no --> A
+```
+
+## 2. Triggering Alerts
+
+1. From the dashboard, open the **Alerts** tab.
+2. Click **New Alert** and fill in the form.
+3. Press **Create** to trigger the alert.
+4. Verify a success notification appears.
+
+![Create Alert](https://placehold.co/600x400?text=New+Alert)
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant UI as Web UI
+    participant API as Alerts API
+    U->>UI: Fill form & submit
+    UI->>API: POST /api/alerts
+    API-->>UI: 201 Created
+    UI-->>U: Show confirmation
+```
+
+## 3. Feedback Flow
+
+1. Click your avatar and choose **Send Feedback**.
+2. Describe any issues or suggestions.
+3. Submit the form to send feedback to the team.
+
+![Feedback Dialog](https://placehold.co/600x400?text=Feedback)
+
+```mermaid
+flowchart LR
+    Start[Open Feedback] --> Form[Fill details]
+    Form --> Submit[Submit feedback]
+    Submit --> End[Confirmation]
+```
+
+<!--
+Screencast Outline (approx. 7 minutes):
+0:00 - 0:30 Introduction and login page overview
+0:30 - 1:30 Demo logging in and viewing the dashboard
+1:30 - 3:30 Create a new alert and confirm notification
+3:30 - 5:00 Walk through existing alerts list
+5:00 - 6:30 Open feedback dialog and submit example feedback
+6:30 - 7:00 Wrap up and where to find more help
+-->


### PR DESCRIPTION
## Summary
- document login, alert creation, and feedback in `docs/user-guide.md`
- add TypeScript SDK usage samples under `docs/sdk`
